### PR TITLE
RALPH: Cart domain -- expose clearCart event on ACL (issue #23 / PRD …

### DIFF
--- a/apps/ecommerce/src/app/domains/cart/application/events.ts
+++ b/apps/ecommerce/src/app/domains/cart/application/events.ts
@@ -32,5 +32,7 @@ export const cartUiEvents = eventGroup({
     decrementOrRemoveItem: type<{ mainProductItemId: number }>(),
     /** Remove a **Cart Item** line entirely regardless of quantity. */
     removeItem: type<{ mainProductItemId: number }>(),
+    /** Clear all **Cart Items** — used by Checkout after a successful order. */
+    clearCart: type<void>(),
   },
 });

--- a/apps/ecommerce/src/app/domains/cart/application/guest-cart.store.spec.ts
+++ b/apps/ecommerce/src/app/domains/cart/application/guest-cart.store.spec.ts
@@ -255,5 +255,35 @@ describe('GuestCartStore', () => {
       expect(store.items()).toHaveLength(0);
       expect(store.totalUnitCount()).toBe(0);
     });
+
+    it('clearCart event resets items to empty array', () => {
+      store.addFromBrowseRow(
+        { productId: 1, mainProductItemId: 11, name: 'H', salePrice: 5, originalPrice: null, primaryImageUrl: null },
+        2
+      );
+      store.addFromBrowseRow(
+        { productId: 2, mainProductItemId: 22, name: 'I', salePrice: 10, originalPrice: null, primaryImageUrl: null },
+        1
+      );
+      expect(store.items()).toHaveLength(2);
+
+      dispatcher.dispatch(cartUiEvents.clearCart());
+
+      expect(store.items()).toHaveLength(0);
+      expect(store.totalUnitCount()).toBe(0);
+    });
+
+    it('clearCart event clears the guest cart entry in localStorage', () => {
+      store.addFromBrowseRow(
+        { productId: 1, mainProductItemId: 55, name: 'J', salePrice: 3, originalPrice: null, primaryImageUrl: null },
+        1
+      );
+
+      dispatcher.dispatch(cartUiEvents.clearCart());
+
+      const raw = localStorage.getItem(GUEST_CART_LOCAL_STORAGE_KEY);
+      const parsed = raw ? JSON.parse(raw) : null;
+      expect(parsed?.items).toEqual([]);
+    });
   });
 });

--- a/apps/ecommerce/src/app/domains/cart/application/guest-cart.store.ts
+++ b/apps/ecommerce/src/app/domains/cart/application/guest-cart.store.ts
@@ -154,6 +154,7 @@ export const GuestCartStore = signalStore(
         payload.mainProductItemId,
       ),
     })),
+    on(cartUiEvents.clearCart, () => () => ({ items: [] })),
   ),
   /** Persist to localStorage after each event has updated state. */
   withEventHandlers((store, events = inject(Events)) => ({
@@ -164,6 +165,7 @@ export const GuestCartStore = signalStore(
         cartUiEvents.incrementItem,
         cartUiEvents.decrementOrRemoveItem,
         cartUiEvents.removeItem,
+        cartUiEvents.clearCart,
       )
       .pipe(
         tap(() => persistItems(store.storage, store.platformId, store.items())),


### PR DESCRIPTION
…#22)

Task: Issue #23 - Checkout v1 [1/5]: Cart domain -- expose clearCart event on ACL.

Key decisions:
- clearCart event added to cartUiEvents eventGroup (Cart owns the write contract)
- withReducer on(cartUiEvents.clearCart) returns state reset to items []
- cartUiEvents.clearCart added to withEventHandlers persistence pipe so localStorage is cleared after reducer runs
- cartUiEvents already re-exported from anti-corruption-layer.ts via public-api.ts -- no new export line required
- Two new unit tests: reducer resets items to [] and localStorage entry has items [] after dispatch

Files:
  MOD: domains/cart/application/events.ts (+clearCart event) MOD: domains/cart/application/guest-cart.store.ts (+reducer handler, +persistence pipe entry) MOD: domains/cart/application/guest-cart.store.spec.ts (+2 clearCart tests)

Tests: 14/14 pass (nx test ecommerce); nx lint ecommerce passes (0 errors).