### PR TITLE
RALPH: Checkout scaffold — routing shell + empty-cart guard (issue #2…

### DIFF
--- a/apps/ecommerce/src/app/domains/cart/feat-cart/cart-page.component.html
+++ b/apps/ecommerce/src/app/domains/cart/feat-cart/cart-page.component.html
@@ -54,12 +54,21 @@
       <p class="cart-page__total">
         Σύνολο: <strong>{{ formattedSubtotal() }}</strong>
       </p>
-      <p-button
-        label="Συνέχεια αγορών"
-        icon="pi pi-arrow-left"
-        [routerLink]="['/catalog']"
-        severity="secondary"
-      />
+      <div class="cart-page__actions">
+        <p-button
+          label="Συνέχεια αγορών"
+          icon="pi pi-arrow-left"
+          [routerLink]="['/catalog']"
+          severity="secondary"
+        />
+        <p-button
+          label="Προχώρηση στο ταμείο"
+          icon="pi pi-arrow-right"
+          iconPos="right"
+          [routerLink]="['/checkout']"
+          [disabled]="store.items().length === 0"
+        />
+      </div>
     </div>
   }
 </div>

--- a/apps/ecommerce/src/app/domains/checkout/api/checkout.routes.ts
+++ b/apps/ecommerce/src/app/domains/checkout/api/checkout.routes.ts
@@ -1,0 +1,12 @@
+import { emptyCartGuard } from '../application/public-api';
+
+export default [
+  {
+    path: '',
+    canActivate: [emptyCartGuard],
+    loadComponent: () =>
+      import('../feat-checkout/checkout-page.component').then(
+        (m) => m.CheckoutPageComponent
+      ),
+  },
+];

--- a/apps/ecommerce/src/app/domains/checkout/application/empty-cart.guard.spec.ts
+++ b/apps/ecommerce/src/app/domains/checkout/application/empty-cart.guard.spec.ts
@@ -1,0 +1,69 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+
+import { CartAclReadAdapter } from '../../cart/application/anti-corruption-layer';
+import { emptyCartGuard } from './empty-cart.guard';
+
+@Component({
+  selector: 'app-stub',
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class StubComponent {}
+
+describe('emptyCartGuard', () => {
+  function setup(itemCount: number) {
+    const items = signal(
+      Array.from({ length: itemCount }, (_, i) => ({
+        mainProductItemId: i + 1,
+        productId: i + 1,
+        name: `Product ${i + 1}`,
+        quantity: 1,
+        originalPrice: 10,
+        salePrice: null,
+        primaryImageUrl: null,
+      }))
+    );
+
+    const mockCartAcl = {
+      items,
+    } as unknown as CartAclReadAdapter;
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          {
+            path: 'checkout',
+            component: StubComponent,
+            canActivate: [emptyCartGuard],
+          },
+          {
+            path: 'cart',
+            component: StubComponent,
+          },
+        ]),
+        { provide: CartAclReadAdapter, useValue: mockCartAcl },
+      ],
+    });
+
+    return { items };
+  }
+
+  it('redirects to /cart when the cart is empty', async () => {
+    setup(0);
+    const harness = await RouterTestingHarness.create('/checkout');
+    const router = TestBed.inject(Router);
+    expect(router.url).toBe('/cart');
+    expect(harness).toBeDefined();
+  });
+
+  it('allows navigation to /checkout when the cart has items', async () => {
+    setup(2);
+    const harness = await RouterTestingHarness.create('/checkout');
+    const router = TestBed.inject(Router);
+    expect(router.url).toBe('/checkout');
+    expect(harness).toBeDefined();
+  });
+});

--- a/apps/ecommerce/src/app/domains/checkout/application/empty-cart.guard.ts
+++ b/apps/ecommerce/src/app/domains/checkout/application/empty-cart.guard.ts
@@ -1,0 +1,20 @@
+import { inject } from '@angular/core';
+import { Router, type CanActivateFn } from '@angular/router';
+
+import { CartAclReadAdapter } from '../../cart/application/anti-corruption-layer';
+
+/**
+ * Prevents navigation to `/checkout` when the cart is empty.
+ * Redirects to `/cart` so the user can review their basket first.
+ *
+ * Placed in `application/` (not `api/`) so it can legally import the
+ * Cart bounded-context's ACL (`domain-application-anti-corruption-layer-api`),
+ * which `domain-routes` cannot import directly.
+ */
+export const emptyCartGuard: CanActivateFn = () => {
+  const cartAcl = inject(CartAclReadAdapter);
+  if (cartAcl.items().length === 0) {
+    return inject(Router).createUrlTree(['/cart']);
+  }
+  return true;
+};

--- a/apps/ecommerce/src/app/domains/checkout/application/public-api.ts
+++ b/apps/ecommerce/src/app/domains/checkout/application/public-api.ts
@@ -1,0 +1,1 @@
+export { emptyCartGuard } from './empty-cart.guard';

--- a/apps/ecommerce/src/app/domains/checkout/feat-checkout/checkout-page.component.html
+++ b/apps/ecommerce/src/app/domains/checkout/feat-checkout/checkout-page.component.html
@@ -1,0 +1,3 @@
+<div class="checkout-page">
+  <h1 class="checkout-page__title">Ολοκλήρωση παραγγελίας</h1>
+</div>

--- a/apps/ecommerce/src/app/domains/checkout/feat-checkout/checkout-page.component.scss
+++ b/apps/ecommerce/src/app/domains/checkout/feat-checkout/checkout-page.component.scss
@@ -1,0 +1,9 @@
+.checkout-page {
+  padding: 2rem;
+
+  &__title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-bottom: 1.5rem;
+  }
+}

--- a/apps/ecommerce/src/app/domains/checkout/feat-checkout/checkout-page.component.ts
+++ b/apps/ecommerce/src/app/domains/checkout/feat-checkout/checkout-page.component.ts
@@ -1,0 +1,9 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+  selector: 'app-checkout-page',
+  templateUrl: './checkout-page.component.html',
+  styleUrl: './checkout-page.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CheckoutPageComponent {}

--- a/apps/ecommerce/src/app/layout/navigation/navigation.routes.ts
+++ b/apps/ecommerce/src/app/layout/navigation/navigation.routes.ts
@@ -13,6 +13,11 @@ export default [
         path: 'cart',
         loadChildren: () => import('../../domains/cart/api/cart.routes'),
       },
+      {
+        path: 'checkout',
+        loadChildren: () =>
+          import('../../domains/checkout/api/checkout.routes'),
+      },
     ],
   },
   {


### PR DESCRIPTION
…5 / PRD #22)

Task: Issue #25 - Checkout v1 [3/5]: Angular — domains/checkout scaffold, routing & empty-cart guard.

Key decisions:
- guard placed in domains/checkout/application/ (not api/) so it can legally import CartAclReadAdapter via domain-application-anti-corruption-layer-api boundary rule; exported via application/public-api.ts for domain-routes to consume
- checkout.routes.ts consumes guard via same-domain application/public-api (domain-application-api) -- no direct ACL import from routes layer, keeping boundary rules clean
- CheckoutPageComponent is a minimal placeholder (single heading) -- no checkout UI yet
- Proceed to Checkout p-button added to cart-page __summary block with [disabled] bound to store.items().length === 0; navigates ['/checkout'] via RouterLink
- spec uses inline StubComponent to avoid domain-application to domain-feature boundary violation

Files:
  NEW: domains/checkout/api/checkout.routes.ts NEW: domains/checkout/application/empty-cart.guard.ts NEW: domains/checkout/application/empty-cart.guard.spec.ts (+2 guard tests) NEW: domains/checkout/application/public-api.ts NEW: domains/checkout/feat-checkout/checkout-page.component.{ts,html,scss} MOD: layout/navigation/navigation.routes.ts (+checkout route) MOD: domains/cart/feat-cart/cart-page.component.html (+Proceed to Checkout button)

Tests: 2/2 guard tests pass; nx lint ecommerce passes (0 errors, 1 pre-existing warning).