### PR TITLE
RALPH: feat(ecommerce-api): guest-to-auth Cart merge endpoint (POST /…

### DIFF
--- a/apps/ecommerce-api/src/modules/cart/application/use-cases/merge-cart.use-case.spec.ts
+++ b/apps/ecommerce-api/src/modules/cart/application/use-cases/merge-cart.use-case.spec.ts
@@ -1,0 +1,221 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import {
+  MergeCartUseCase,
+  ProductItemExistenceChecker,
+} from './merge-cart.use-case';
+import { CartRepository } from '../../domain/repositories/cart.repository';
+import { Cart } from '../../domain/cart.types';
+
+function buildCart(overrides: Partial<Cart> = {}): Cart {
+  return {
+    id: 1,
+    userId: 'user-uuid-123',
+    items: [],
+    ...overrides,
+  };
+}
+
+describe('MergeCartUseCase', () => {
+  let useCase: MergeCartUseCase;
+  const mergeItems = jest.fn();
+  const getCartByUserId = jest.fn();
+  const isActive = jest.fn();
+
+  beforeEach(async () => {
+    mergeItems.mockReset();
+    getCartByUserId.mockReset();
+    isActive.mockReset();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MergeCartUseCase,
+        {
+          provide: CartRepository,
+          useValue: { mergeItems, getCartByUserId },
+        },
+        {
+          provide: ProductItemExistenceChecker,
+          useValue: { isActive },
+        },
+      ],
+    }).compile();
+
+    useCase = module.get(MergeCartUseCase);
+  });
+
+  it('inserts new cart items for valid guest lines', async () => {
+    isActive.mockResolvedValue(true);
+    const updatedCart = buildCart({
+      items: [
+        {
+          id: 10,
+          cartId: 1,
+          productItemId: 42,
+          quantity: 2,
+          capturedPrice: 19.99,
+          currentPrice: 19.99,
+          capturedName: 'Widget A',
+          capturedImageUrl: 'https://example.com/img.jpg',
+          available: true,
+        },
+      ],
+    });
+    mergeItems.mockResolvedValue(updatedCart);
+
+    const result = await useCase.execute({
+      userId: 'user-uuid-123',
+      items: [
+        {
+          productItemId: 42,
+          quantity: 2,
+          capturedSalePrice: 19.99,
+          capturedName: 'Widget A',
+          capturedImageUrl: 'https://example.com/img.jpg',
+        },
+      ],
+    });
+
+    expect(isActive).toHaveBeenCalledWith(42);
+    expect(mergeItems).toHaveBeenCalledWith({
+      userId: 'user-uuid-123',
+      items: [
+        {
+          productItemId: 42,
+          quantity: 2,
+          capturedSalePrice: 19.99,
+          capturedName: 'Widget A',
+          capturedImageUrl: 'https://example.com/img.jpg',
+        },
+      ],
+    });
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].productItemId).toBe(42);
+  });
+
+  it('combines quantities and refreshes snapshot for existing lines', async () => {
+    isActive.mockResolvedValue(true);
+    const updatedCart = buildCart({
+      items: [
+        {
+          id: 10,
+          cartId: 1,
+          productItemId: 42,
+          quantity: 5,
+          capturedPrice: 25.0,
+          currentPrice: 25.0,
+          capturedName: 'Widget A v2',
+          capturedImageUrl: null,
+          available: true,
+        },
+      ],
+    });
+    mergeItems.mockResolvedValue(updatedCart);
+
+    const result = await useCase.execute({
+      userId: 'user-uuid-123',
+      items: [
+        {
+          productItemId: 42,
+          quantity: 3,
+          capturedSalePrice: 25.0,
+          capturedName: 'Widget A v2',
+          capturedImageUrl: null,
+        },
+      ],
+    });
+
+    expect(mergeItems).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [
+          expect.objectContaining({
+            productItemId: 42,
+            quantity: 3,
+            capturedSalePrice: 25.0,
+          }),
+        ],
+      }),
+    );
+    expect(result.items[0].quantity).toBe(5);
+    expect(result.items[0].capturedName).toBe('Widget A v2');
+  });
+
+  it('silently drops lines whose product_item_id is archived or deleted', async () => {
+    isActive.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const updatedCart = buildCart({
+      items: [
+        {
+          id: 20,
+          cartId: 1,
+          productItemId: 99,
+          quantity: 1,
+          capturedPrice: 10.0,
+          currentPrice: 10.0,
+          capturedName: 'Valid Item',
+          capturedImageUrl: null,
+          available: true,
+        },
+      ],
+    });
+    mergeItems.mockResolvedValue(updatedCart);
+
+    const result = await useCase.execute({
+      userId: 'user-uuid-123',
+      items: [
+        {
+          productItemId: 1,
+          quantity: 2,
+          capturedSalePrice: 5.0,
+          capturedName: 'Archived Item',
+          capturedImageUrl: null,
+        },
+        {
+          productItemId: 99,
+          quantity: 1,
+          capturedSalePrice: 10.0,
+          capturedName: 'Valid Item',
+          capturedImageUrl: null,
+        },
+      ],
+    });
+
+    expect(mergeItems).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [
+          expect.objectContaining({ productItemId: 99 }),
+        ],
+      }),
+    );
+    expect(result.items).toHaveLength(1);
+  });
+
+  it('is a no-op and returns the current cart when items array is empty', async () => {
+    const currentCart = buildCart({
+      items: [
+        {
+          id: 5,
+          cartId: 1,
+          productItemId: 77,
+          quantity: 1,
+          capturedPrice: 9.99,
+          currentPrice: 9.99,
+          capturedName: 'Existing Item',
+          capturedImageUrl: null,
+          available: true,
+        },
+      ],
+    });
+    getCartByUserId.mockResolvedValue(currentCart);
+
+    const result = await useCase.execute({
+      userId: 'user-uuid-123',
+      items: [],
+    });
+
+    expect(isActive).not.toHaveBeenCalled();
+    expect(mergeItems).not.toHaveBeenCalled();
+    expect(getCartByUserId).toHaveBeenCalledWith('user-uuid-123');
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].productItemId).toBe(77);
+  });
+});

--- a/apps/ecommerce-api/src/modules/cart/application/use-cases/merge-cart.use-case.ts
+++ b/apps/ecommerce-api/src/modules/cart/application/use-cases/merge-cart.use-case.ts
@@ -1,0 +1,68 @@
+import { Injectable } from '@nestjs/common';
+
+import { CartRepository } from '../../domain/repositories/cart.repository';
+import { Cart } from '../../domain/cart.types';
+import { CartResponseDto } from '../dto/cart-response.dto';
+
+export interface MergeCartItemCommand {
+  productItemId: number;
+  quantity: number;
+  capturedSalePrice: number;
+  capturedName: string;
+  capturedImageUrl?: string | null;
+}
+
+export interface MergeCartCommand {
+  userId: string;
+  items: MergeCartItemCommand[];
+}
+
+export abstract class ProductItemExistenceChecker {
+  abstract isActive(productItemId: number): Promise<boolean>;
+}
+
+@Injectable()
+export class MergeCartUseCase {
+  constructor(
+    private readonly cartRepository: CartRepository,
+    private readonly existenceChecker: ProductItemExistenceChecker,
+  ) {}
+
+  async execute(command: MergeCartCommand): Promise<CartResponseDto> {
+    if (command.items.length === 0) {
+      const cart = await this.cartRepository.getCartByUserId(command.userId);
+      return this.mapCartToDto(cart);
+    }
+
+    const validItems: MergeCartItemCommand[] = [];
+    for (const item of command.items) {
+      if (await this.existenceChecker.isActive(item.productItemId)) {
+        validItems.push(item);
+      }
+    }
+
+    const cart = await this.cartRepository.mergeItems({
+      userId: command.userId,
+      items: validItems,
+    });
+
+    return this.mapCartToDto(cart);
+  }
+
+  private mapCartToDto(cart: Cart): CartResponseDto {
+    return {
+      id: cart.id,
+      userId: cart.userId,
+      items: cart.items.map((item) => ({
+        id: item.id,
+        productItemId: item.productItemId,
+        quantity: item.quantity,
+        capturedPrice: item.capturedPrice,
+        currentPrice: item.currentPrice,
+        capturedName: item.capturedName,
+        capturedImageUrl: item.capturedImageUrl,
+        available: item.available,
+      })),
+    };
+  }
+}

--- a/apps/ecommerce-api/src/modules/cart/cart.module.ts
+++ b/apps/ecommerce-api/src/modules/cart/cart.module.ts
@@ -7,10 +7,13 @@ import { GetCartUseCase } from './application/use-cases/get-cart.use-case';
 import { AddCartItemUseCase } from './application/use-cases/add-cart-item.use-case';
 import { UpdateCartItemUseCase } from './application/use-cases/update-cart-item.use-case';
 import { RemoveCartItemUseCase } from './application/use-cases/remove-cart-item.use-case';
+import { MergeCartUseCase } from './application/use-cases/merge-cart.use-case';
 import { CartRepository } from './domain/repositories/cart.repository';
 import { ProductItemSnapshotProvider } from './application/use-cases/add-cart-item.use-case';
+import { ProductItemExistenceChecker } from './application/use-cases/merge-cart.use-case';
 import { DrizzleCartRepository } from './infrastructure/drizzle-cart.repository';
 import { DrizzleProductItemSnapshotProvider } from './infrastructure/drizzle-product-item-snapshot.provider';
+import { DrizzleProductItemExistenceChecker } from './infrastructure/drizzle-product-item-existence-checker';
 
 @Module({
   imports: [SupabaseAuthModule],
@@ -20,6 +23,7 @@ import { DrizzleProductItemSnapshotProvider } from './infrastructure/drizzle-pro
     AddCartItemUseCase,
     UpdateCartItemUseCase,
     RemoveCartItemUseCase,
+    MergeCartUseCase,
     {
       provide: CartRepository,
       useClass: DrizzleCartRepository,
@@ -27,6 +31,10 @@ import { DrizzleProductItemSnapshotProvider } from './infrastructure/drizzle-pro
     {
       provide: ProductItemSnapshotProvider,
       useClass: DrizzleProductItemSnapshotProvider,
+    },
+    {
+      provide: ProductItemExistenceChecker,
+      useClass: DrizzleProductItemExistenceChecker,
     },
   ],
 })

--- a/apps/ecommerce-api/src/modules/cart/domain/repositories/cart.repository.ts
+++ b/apps/ecommerce-api/src/modules/cart/domain/repositories/cart.repository.ts
@@ -22,4 +22,15 @@ export abstract class CartRepository {
     userId: string;
     cartItemId: number;
   }): Promise<Cart>;
+
+  abstract mergeItems(params: {
+    userId: string;
+    items: Array<{
+      productItemId: number;
+      quantity: number;
+      capturedSalePrice: number;
+      capturedName: string;
+      capturedImageUrl?: string | null;
+    }>;
+  }): Promise<Cart>;
 }

--- a/apps/ecommerce-api/src/modules/cart/infrastructure/drizzle-cart.repository.ts
+++ b/apps/ecommerce-api/src/modules/cart/infrastructure/drizzle-cart.repository.ts
@@ -127,6 +127,62 @@ export class DrizzleCartRepository implements CartRepository {
     return this.enrichCart(cart.id, params.userId);
   }
 
+  async mergeItems(params: {
+    userId: string;
+    items: Array<{
+      productItemId: number;
+      quantity: number;
+      capturedSalePrice: number;
+      capturedName: string;
+      capturedImageUrl?: string | null;
+    }>;
+  }): Promise<Cart> {
+    const cart = await this.ensureCart(params.userId);
+
+    for (const item of params.items) {
+      const [existing] = await this.drizzle.db
+        .select()
+        .from(cartItems)
+        .where(
+          and(
+            eq(cartItems.cartId, cart.id),
+            eq(cartItems.productItemId, item.productItemId),
+          ),
+        );
+
+      if (existing) {
+        await this.drizzle.db
+          .update(cartItems)
+          .set({
+            quantity: existing.quantity + item.quantity,
+            capturedSalePrice: item.capturedSalePrice,
+            capturedName: item.capturedName,
+            capturedImageUrl: item.capturedImageUrl ?? null,
+            updatedAt: new Date(),
+          })
+          .where(eq(cartItems.id, existing.id));
+      } else {
+        await this.drizzle.db.insert(cartItems).values({
+          cartId: cart.id,
+          productItemId: item.productItemId,
+          quantity: item.quantity,
+          capturedSalePrice: item.capturedSalePrice,
+          capturedName: item.capturedName,
+          capturedImageUrl: item.capturedImageUrl ?? null,
+        });
+      }
+    }
+
+    if (params.items.length > 0) {
+      await this.drizzle.db
+        .update(carts)
+        .set({ updatedAt: new Date() })
+        .where(eq(carts.id, cart.id));
+    }
+
+    return this.enrichCart(cart.id, params.userId);
+  }
+
   private async ensureCart(userId: string): Promise<{ id: number }> {
     const [existing] = await this.drizzle.db
       .select({ id: carts.id })

--- a/apps/ecommerce-api/src/modules/cart/infrastructure/drizzle-product-item-existence-checker.ts
+++ b/apps/ecommerce-api/src/modules/cart/infrastructure/drizzle-product-item-existence-checker.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { eq, and, isNull } from 'drizzle-orm';
+
+import { DrizzleService } from '../../../drizzle/drizzle.service';
+import { productItems } from '../../../db/schema/product-items';
+import { ProductItemExistenceChecker } from '../application/use-cases/merge-cart.use-case';
+
+@Injectable()
+export class DrizzleProductItemExistenceChecker
+  implements ProductItemExistenceChecker
+{
+  constructor(private readonly drizzle: DrizzleService) {}
+
+  async isActive(productItemId: number): Promise<boolean> {
+    const [row] = await this.drizzle.db
+      .select({ id: productItems.id })
+      .from(productItems)
+      .where(
+        and(
+          eq(productItems.id, productItemId),
+          isNull(productItems.deletedAt),
+        ),
+      )
+      .limit(1);
+
+    return row !== undefined;
+  }
+}

--- a/apps/ecommerce-api/src/modules/cart/presentation/controllers/cart.controller.ts
+++ b/apps/ecommerce-api/src/modules/cart/presentation/controllers/cart.controller.ts
@@ -17,8 +17,10 @@ import { GetCartUseCase } from '../../application/use-cases/get-cart.use-case';
 import { AddCartItemUseCase } from '../../application/use-cases/add-cart-item.use-case';
 import { UpdateCartItemUseCase } from '../../application/use-cases/update-cart-item.use-case';
 import { RemoveCartItemUseCase } from '../../application/use-cases/remove-cart-item.use-case';
+import { MergeCartUseCase } from '../../application/use-cases/merge-cart.use-case';
 import { AddCartItemDto } from '../dto/add-cart-item.dto';
 import { UpdateCartItemDto } from '../dto/update-cart-item.dto';
+import { MergeCartDto } from '../dto/merge-cart.dto';
 import { SupabaseAuthGuard } from '@full-stack-nx-workspace/auth';
 
 @UseGuards(SupabaseAuthGuard)
@@ -29,6 +31,7 @@ export class CartController {
     private readonly addCartItemUseCase: AddCartItemUseCase,
     private readonly updateCartItemUseCase: UpdateCartItemUseCase,
     private readonly removeCartItemUseCase: RemoveCartItemUseCase,
+    private readonly mergeCartUseCase: MergeCartUseCase,
   ) {}
 
   @Get()
@@ -70,6 +73,24 @@ export class CartController {
     return this.removeCartItemUseCase.execute({
       userId: req.user.id,
       cartItemId,
+    });
+  }
+
+  @Post('merge')
+  @HttpCode(HttpStatus.OK)
+  merge(
+    @Body() dto: MergeCartDto,
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.mergeCartUseCase.execute({
+      userId: req.user.id,
+      items: dto.items.map((item) => ({
+        productItemId: item.productItemId,
+        quantity: item.quantity,
+        capturedSalePrice: item.capturedSalePrice,
+        capturedName: item.capturedName,
+        capturedImageUrl: item.capturedImageUrl ?? null,
+      })),
     });
   }
 }

--- a/apps/ecommerce-api/src/modules/cart/presentation/dto/merge-cart.dto.ts
+++ b/apps/ecommerce-api/src/modules/cart/presentation/dto/merge-cart.dto.ts
@@ -1,0 +1,38 @@
+import {
+  IsArray,
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsPositive,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class MergeCartItemDto {
+  @IsInt()
+  @IsPositive()
+  productItemId!: number;
+
+  @IsInt()
+  @IsPositive()
+  quantity!: number;
+
+  @IsNumber()
+  @IsPositive()
+  capturedSalePrice!: number;
+
+  @IsString()
+  capturedName!: string;
+
+  @IsOptional()
+  @IsString()
+  capturedImageUrl?: string | null;
+}
+
+export class MergeCartDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => MergeCartItemDto)
+  items!: MergeCartItemDto[];
+}


### PR DESCRIPTION
…cart/merge) -- issue #35

Task: Issue #35 -- add POST /cart/merge to CartModule for guest-to-auth cart merge on sign-in.

Key decisions:
- MergeCartUseCase iterates guest items, validates each product_item_id via ProductItemExistenceChecker (isActive checks deletedAt IS NULL), silently drops archived/non-existent items, then delegates bulk upsert to CartRepository.mergeItems
- ProductItemExistenceChecker defined as abstract class in merge-cart.use-case.ts (mirrors ProductItemSnapshotProvider pattern); DrizzleProductItemExistenceChecker filters by deletedAt IS NULL
- CartRepository.mergeItems added to abstract class; DrizzleCartRepository upserts (quantity-add + snapshot-refresh on match, insert on new)
- Empty items array is a no-op -- returns current cart via getCartByUserId without calling mergeItems
- MergeCartDto uses ValidateNested + @Type for nested item validation; capturedImageUrl is optional

Files:
  NEW: presentation/dto/merge-cart.dto.ts NEW: application/use-cases/merge-cart.use-case.ts NEW: application/use-cases/merge-cart.use-case.spec.ts (4 unit tests) NEW: infrastructure/drizzle-product-item-existence-checker.ts MOD: domain/repositories/cart.repository.ts (+mergeItems abstract) MOD: infrastructure/drizzle-cart.repository.ts (+mergeItems impl) MOD: presentation/controllers/cart.controller.ts (+POST merge endpoint) MOD: cart.module.ts (+MergeCartUseCase, +ProductItemExistenceChecker binding)

Tests: 41 passed (37 to 41), typecheck clean.