### PR TITLE
RALPH: NL start for Cart Item workflow (#58, PRD #56)

### DIFF
--- a/ai-server/jest.config.ts
+++ b/ai-server/jest.config.ts
@@ -1,0 +1,10 @@
+export default {
+  displayName: 'ai-server',
+  preset: '../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../coverage/ai-server',
+};

--- a/ai-server/project.json
+++ b/ai-server/project.json
@@ -1,0 +1,14 @@
+{
+  "name": "ai-server",
+  "$schema": "../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "ai-server/src",
+  "projectType": "application",
+  "tags": [],
+  "targets": {
+    "test": {
+      "options": {
+        "passWithNoTests": false
+      }
+    }
+  }
+}

--- a/ai-server/src/mastra/agents/shopping-agent.instructions.spec.ts
+++ b/ai-server/src/mastra/agents/shopping-agent.instructions.spec.ts
@@ -1,0 +1,75 @@
+import {
+  SHOPPING_AGENT_CONVERSION_INSTRUCTIONS,
+  SHOPPING_AGENT_INSTRUCTIONS,
+} from './shopping-agent.instructions';
+
+describe('Shopping Assistant conversion instructions', () => {
+  it('starts conversion from an ordinal or name in this thread’s last Product recommendations', () => {
+    expect(SHOPPING_AGENT_CONVERSION_INSTRUCTIONS).toMatch(/add the second one/i);
+    expect(SHOPPING_AGENT_CONVERSION_INSTRUCTIONS).toMatch(
+      /last Product recommendations/i,
+    );
+    expect(SHOPPING_AGENT_CONVERSION_INSTRUCTIONS).toMatch(/naming/i);
+  });
+
+  it('forwards option hints from that utterance as raw text, never a Product Item id', () => {
+    expect(SHOPPING_AGENT_CONVERSION_INSTRUCTIONS).toMatch(
+      /option hints in that utterance as raw text/i,
+    );
+    expect(SHOPPING_AGENT_CONVERSION_INSTRUCTIONS).toMatch(
+      /Never pass a Product Item id/i,
+    );
+  });
+
+  it('refuses a first message that names a Product with no last-turn recommendation', () => {
+    expect(SHOPPING_AGENT_CONVERSION_INSTRUCTIONS).toMatch(
+      /add the blue Nike/i,
+    );
+    expect(SHOPPING_AGENT_CONVERSION_INSTRUCTIONS).toMatch(
+      /not a catalog name resolver/i,
+    );
+    expect(SHOPPING_AGENT_CONVERSION_INSTRUCTIONS).toMatch(
+      /no last Product recommendation/i,
+    );
+  });
+
+  it('does not offer product-detail add this', () => {
+    expect(SHOPPING_AGENT_CONVERSION_INSTRUCTIONS).toMatch(
+      /Product-detail "add this" is not offered/i,
+    );
+  });
+
+  it('resolves one Product when the shopper asks to add two last-turn recommendations', () => {
+    expect(SHOPPING_AGENT_CONVERSION_INSTRUCTIONS).toMatch(
+      /add the second and the third/i,
+    );
+    expect(SHOPPING_AGENT_CONVERSION_INSTRUCTIONS).toMatch(
+      /first mentioned, or ask which/i,
+    );
+    expect(SHOPPING_AGENT_CONVERSION_INSTRUCTIONS).toMatch(
+      /Do not start two conversions/i,
+    );
+  });
+
+  it('does not teach A2UI authoring or name tools', () => {
+    expect(SHOPPING_AGENT_INSTRUCTIONS).not.toMatch(/NEVER plain text/i);
+    expect(SHOPPING_AGENT_INSTRUCTIONS).not.toMatch(/ALWAYS render/i);
+    expect(SHOPPING_AGENT_INSTRUCTIONS).not.toMatch(/renderA2ui/i);
+    expect(SHOPPING_AGENT_INSTRUCTIONS).not.toMatch(/search_products_by_need/);
+    expect(SHOPPING_AGENT_INSTRUCTIONS).not.toMatch(/cart-item-workflow/);
+    expect(SHOPPING_AGENT_INSTRUCTIONS).not.toMatch(/\bcartItem\b/);
+  });
+
+  it('keeps retrieval, idle off-catalog chat, and account/Order refusal', () => {
+    expect(SHOPPING_AGENT_INSTRUCTIONS).toMatch(
+      /Search only when the message is a product need/i,
+    );
+    expect(SHOPPING_AGENT_INSTRUCTIONS).toMatch(/Off-catalog topics: refuse/i);
+    expect(SHOPPING_AGENT_INSTRUCTIONS).toMatch(
+      /orders, account.*say you only recommend Products/i,
+    );
+    expect(SHOPPING_AGENT_INSTRUCTIONS).toMatch(
+      /These instructions never name tools/i,
+    );
+  });
+});

--- a/ai-server/src/mastra/agents/shopping-agent.instructions.ts
+++ b/ai-server/src/mastra/agents/shopping-agent.instructions.ts
@@ -1,0 +1,42 @@
+export const SHOPPING_AGENT_CONVERSION_INSTRUCTIONS = `When to convert a last-turn Product
+- Start conversion only when the shopper asks to add a Product from this thread's last Product recommendations: an ordinal ("add the second one") or naming one of those recommended Products. That is the same conversion a card Add starts.
+- Pass that Product's id (from those recommendations) and any option hints in that utterance as raw text (for example "red, 42" from "the second one in red, 42"). Never pass a Product Item id. Do not pick size or color yourself.
+- If there is no last Product recommendation in this thread, refuse. Do not start conversion. You are not a catalog name resolver: a first message like "add the blue Nike" does not start conversion. Product-detail "add this" is not offered.
+- If they ask to add more than one recommended Product ("add the second and the third"), resolve one Product: the first mentioned, or ask which. Do not start two conversions. One conversion produces one Cart Item.
+- Do not write the Cart. Do not author confirm or picker UI; that comes from the conversion result.
+- Greetings, product-need search, cart/checkout/account/order questions, and off-catalog topics: do not start conversion. Idle chat (no in-flight conversion) still searches only on a product need and still refuses account and Order questions.
+`;
+
+export const SHOPPING_AGENT_INSTRUCTIONS = `You are the storefront Shopping Assistant. You recommend Products from a stated product need. You do not add to the Cart, change catalog filters, pick a Product Item (size/color), or answer account/order questions.
+
+When to search
+- Search only when the message is a product need (a kind of Product, a use, or a constraint such as "waterproof shoes for hiking").
+- Greetings: invite the shopper to describe what they need. Do not search.
+- Cart, checkout, orders, account (except adding a last-turn recommended Product): say you only recommend Products. Do not fake those actions. Do not search.
+- Off-catalog topics: refuse. Do not search.
+
+Query
+- Pass the need as natural language. Strip chitchat. Do not turn it into keywords.
+- Do not add budget, brand, or specs the shopper did not say.
+- Do not send any Instruct/Query prefix; the API wraps the query.
+- Follow-ups that refine the need ("lighter", "for hiking"): reconstruct the full need as a sentence from this thread and search again.
+- "The second one" / "that jacket": refer to the last Product recommendations (name + path). Do not search unless they also change the need.
+- One search per shopper turn. If every hit is a poor fit, do not guess a second query.
+
+Data rules
+- These instructions never name tools. Select a tool only when the shopper's request matches that tool's description. If none matches, do not call a tool.
+- Recommend only from search results in this turn. Do not invent a Product or recommend from memory as if it were a new search.
+- The why may only cite name, category path, sale price, excerpt, and options. Do not invent specs, stock, ratings, or features that are not in those fields.
+- Do not print similarity scores.
+- Do not translate Product names, options, or category path.
+
+Using results
+- Search returns up to 8 Products with similarity, category path, Main Product Item sale price, storefront path, a short excerpt, and options.
+- Present at most 3 Products whose fields actually support the need. If only one is honest, show one. If none are, say so in one sentence and ask one narrowing question. Do not show Product cards when none fit.
+- Show each recommendation as an interactive Product card in the chat (one card per Product: id, name, Sale Price). Do not list Products as markdown links or a text catalog; the cards are the Product list.
+- Search before showing cards. Showing the cards ends the turn, so emit every card for this turn together after search is done.
+- You may add a short why in the same turn as the cards. Reply in the shopper's language; a Greek why may still cite an English name.
+
+When search fails (API or embedding error): say Product search is unavailable. Do not recommend from memory as if it were a new search.
+
+${SHOPPING_AGENT_CONVERSION_INSTRUCTIONS}`;

--- a/ai-server/src/mastra/agents/shopping-agent.ts
+++ b/ai-server/src/mastra/agents/shopping-agent.ts
@@ -4,6 +4,7 @@ import { Memory } from '@mastra/memory';
 import { model } from '../config';
 import { searchProductsByNeedTool } from '../tools/search-products-by-need-tool';
 import { cartItemWorkflow } from '../workflows/cart-item-workflow';
+import { SHOPPING_AGENT_INSTRUCTIONS } from './shopping-agent.instructions';
 
 export const shoppingAgent = new Agent({
   id: 'shoppingAgent',
@@ -18,44 +19,7 @@ export const shoppingAgent = new Agent({
       'TV for PS5 gaming',
     ],
   },
-  instructions: `You are the storefront Shopping Assistant. You recommend Products from a stated product need. You do not add to the Cart, change catalog filters, pick a Product Item (size/color), or answer account/order questions.
-
-When to search
-- Search only when the message is a product need (a kind of Product, a use, or a constraint such as "waterproof shoes for hiking").
-- Greetings: invite the shopper to describe what they need. Do not search.
-- Cart, checkout, orders, account (except adding a last-turn recommended Product): say you only recommend Products. Do not fake those actions. Do not search.
-- Off-catalog topics: refuse. Do not search.
-
-Query
-- Pass the need as natural language. Strip chitchat. Do not turn it into keywords.
-- Do not add budget, brand, or specs the shopper did not say.
-- Do not send any Instruct/Query prefix; the API wraps the query.
-- Follow-ups that refine the need ("lighter", "for hiking"): reconstruct the full need as a sentence from this thread and search again.
-- "The second one" / "that jacket": refer to the last Product recommendations (name + path). Do not search unless they also change the need.
-- One search per shopper turn. If every hit is a poor fit, do not guess a second query.
-
-Data rules
-- These instructions never name tools. Select a tool only when the shopper's request matches that tool's description. If none matches, do not call a tool.
-- Recommend only from search results in this turn. Do not invent a Product or recommend from memory as if it were a new search.
-- The why may only cite name, category path, sale price, excerpt, and options. Do not invent specs, stock, ratings, or features that are not in those fields.
-- Do not print similarity scores.
-- Do not translate Product names, options, or category path.
-
-Using results
-- Search returns up to 8 Products with similarity, category path, Main Product Item sale price, storefront path, a short excerpt, and options.
-- Present at most 3 Products whose fields actually support the need. If only one is honest, show one. If none are, say so in one sentence and ask one narrowing question. Do not show Product cards when none fit.
-- Show each recommendation as an interactive Product card in the chat (one card per Product: id, name, Sale Price). Do not list Products as markdown links or a text catalog; the cards are the Product list.
-- Search before showing cards. Showing the cards ends the turn, so emit every card for this turn together after search is done.
-- You may add a short why in the same turn as the cards. Reply in the shopper's language; a Greek why may still cite an English name.
-
-When search fails (API or embedding error): say Product search is unavailable. Do not recommend from memory as if it were a new search.
-
-When to convert a last-turn Product
-- Start conversion only when the shopper asks to add a Product from this thread's recommendations.
-- Pass that Product's id and any option hints they typed as raw text. Never pass a Product Item id. Do not pick size or color yourself.
-- Do not write the Cart. Do not author confirm or picker UI; that comes from the conversion result.
-- Greetings, product-need search, cart/checkout/account questions, and off-catalog topics: do not start conversion.
-`,
+  instructions: SHOPPING_AGENT_INSTRUCTIONS,
   model,
   tools: {
     search_products_by_need: searchProductsByNeedTool,

--- a/ai-server/src/mastra/workflows/cart-item-workflow.contract.spec.ts
+++ b/ai-server/src/mastra/workflows/cart-item-workflow.contract.spec.ts
@@ -1,0 +1,37 @@
+import {
+  CART_ITEM_WORKFLOW_DESCRIPTION,
+  cartItemWorkflowInputSchema,
+} from './cart-item-workflow.contract';
+
+describe('Cart Item workflow start contract', () => {
+  it('accepts a last-turn Product id plus optional hintText, never a Product Item id', () => {
+    expect(cartItemWorkflowInputSchema.shape.productId).toBeDefined();
+    expect(cartItemWorkflowInputSchema.shape.hintText).toBeDefined();
+    expect(cartItemWorkflowInputSchema.shape).not.toHaveProperty(
+      'productItemId',
+    );
+
+    expect(cartItemWorkflowInputSchema.shape.productId.description).toMatch(
+      /Product id from this thread's last Product recommendations/i,
+    );
+    expect(cartItemWorkflowInputSchema.shape.productId.description).toMatch(
+      /Never a Product Item id/i,
+    );
+    expect(cartItemWorkflowInputSchema.shape.hintText.description).toMatch(
+      /option hints from this utterance/i,
+    );
+  });
+
+  it('describes starting conversion for one last-turn recommended Product, including natural-language add', () => {
+    expect(CART_ITEM_WORKFLOW_DESCRIPTION).toMatch(
+      /last Product recommendations/i,
+    );
+    expect(CART_ITEM_WORKFLOW_DESCRIPTION).toMatch(/the second one/i);
+    expect(CART_ITEM_WORKFLOW_DESCRIPTION).toMatch(/hintText/);
+    expect(CART_ITEM_WORKFLOW_DESCRIPTION).toMatch(/Never a Product Item id/i);
+    expect(CART_ITEM_WORKFLOW_DESCRIPTION).toMatch(
+      /no last-turn Product recommendation/i,
+    );
+    expect(CART_ITEM_WORKFLOW_DESCRIPTION).not.toMatch(/productItemId/);
+  });
+});

--- a/ai-server/src/mastra/workflows/cart-item-workflow.contract.ts
+++ b/ai-server/src/mastra/workflows/cart-item-workflow.contract.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const CART_ITEM_WORKFLOW_ID = 'cart-item-workflow';
+
+export const CART_ITEM_WORKFLOW_DESCRIPTION =
+  'Start Cart Item conversion for one Product from this thread\'s last Product recommendations. Use when the shopper asks to add a last-turn recommendation (ordinal like "the second one", or by name), including option hints in that utterance. Input is that Product id plus optional raw option hints as hintText. Never a Product Item id. Do not use when there is no last-turn Product recommendation (including a first message that names a Product), for product-detail add, or to convert more than one Product in one run. Returns an A2UI confirm surface; does not write the Cart.';
+
+export const cartItemWorkflowInputSchema = z.object({
+  productId: z.coerce
+    .number()
+    .int()
+    .positive()
+    .describe(
+      "Product id from this thread's last Product recommendations. Never a Product Item id.",
+    ),
+  hintText: z
+    .string()
+    .optional()
+    .describe(
+      'Raw option hints from this utterance (color, size, and similar). Omit when the shopper stated none. Never a Product Item id.',
+    ),
+});

--- a/ai-server/src/mastra/workflows/cart-item-workflow.ts
+++ b/ai-server/src/mastra/workflows/cart-item-workflow.ts
@@ -1,6 +1,12 @@
 import { createStep, createWorkflow } from '@mastra/core/workflows';
 import { z } from 'zod';
 
+import {
+  CART_ITEM_WORKFLOW_DESCRIPTION,
+  CART_ITEM_WORKFLOW_ID,
+  cartItemWorkflowInputSchema,
+} from './cart-item-workflow.contract';
+
 const BASIC_CATALOG_ID =
   'https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json';
 
@@ -31,11 +37,6 @@ const conversionResultSchema = z.discriminatedUnion('status', [
   z.object({ status: z.literal('all_out_of_stock') }),
   z.object({ status: z.literal('not_found') }),
 ]);
-
-const workflowInputSchema = z.object({
-  productId: z.coerce.number().int().positive(),
-  hintText: z.string().optional(),
-});
 
 const a2uiMessageSchema = z.record(z.string(), z.unknown());
 
@@ -212,7 +213,7 @@ const convertProductItemStep = createStep({
   id: 'convert-product-item',
   description:
     'Resolve a Product plus optional option hints to a unique In Stock Product Item and return the A2UI confirm surface.',
-  inputSchema: workflowInputSchema,
+  inputSchema: cartItemWorkflowInputSchema,
   outputSchema: workflowOutputSchema,
   execute: async ({ inputData, abortSignal }) => {
     const { productId, hintText } = inputData;
@@ -261,10 +262,9 @@ const convertProductItemStep = createStep({
 });
 
 export const cartItemWorkflow = createWorkflow({
-  id: 'cart-item-workflow',
-  description:
-    'Start Cart Item conversion for a last-turn recommended Product. Input is the Product id plus optional raw option hints. Never a Product Item id. Returns an A2UI confirm surface; does not write the Cart.',
-  inputSchema: workflowInputSchema,
+  id: CART_ITEM_WORKFLOW_ID,
+  description: CART_ITEM_WORKFLOW_DESCRIPTION,
+  inputSchema: cartItemWorkflowInputSchema,
   outputSchema: workflowOutputSchema,
 })
   .then(convertProductItemStep)

--- a/ai-server/tsconfig.spec.json
+++ b/ai-server/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "rootDir": ".",
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "esModuleInterop": true,
+    "types": ["jest", "node"],
+    "noEmit": true
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts",
+    "src/mastra/agents/shopping-agent.instructions.ts",
+    "src/mastra/workflows/cart-item-workflow.contract.ts"
+  ]
+}


### PR DESCRIPTION
shoppingAgent now describes when to convert a last-turn Product (ordinal/name + utterance hints), refuse a named Product with no recommendation, and resolve one Product from multi-add. Workflow input schema labels productId/hintText so the model never submits a Product Item id.

Files: shopping-agent instructions, cart-item-workflow contract, ai-server jest project.

Notes: option pickers/OOS remain #59; in-flight abandon/switch remain #60. No sub-agent; no A2UI-authoring instructions.