### PR TITLE
RALPH: kit form leaves in shared (#67, PRD #65)

### DIFF
--- a/libs/shared/eslint.config.mjs
+++ b/libs/shared/eslint.config.mjs
@@ -1,3 +1,42 @@
+import nx from '@nx/eslint-plugin';
 import baseConfig from '../../eslint.config.mjs';
 
-export default [...baseConfig];
+export default [
+  ...baseConfig,
+  ...nx.configs['flat/angular'],
+  {
+    files: ['**/*.ts'],
+    rules: {
+      '@angular-eslint/directive-selector': [
+        'error',
+        {
+          type: 'attribute',
+          prefix: 'lib',
+          style: 'camelCase',
+        },
+      ],
+      '@angular-eslint/component-selector': [
+        'error',
+        {
+          type: 'element',
+          prefix: 'lib',
+          style: 'kebab-case',
+        },
+      ],
+    },
+  },
+  {
+    // Pre-existing app- selectors stay until later kit/assistant tickets.
+    files: [
+      '**/ui-kit/card/**/*.ts',
+      '**/ui-kit/image/**/*.ts',
+      '**/ui-kit/paginator/**/*.ts',
+      '**/ui-assistant/**/*.ts',
+      '**/util-copilotkit/**/*.ts',
+    ],
+    rules: {
+      '@angular-eslint/directive-selector': 'off',
+      '@angular-eslint/component-selector': 'off',
+    },
+  },
+];

--- a/libs/shared/src/lib/ui-kit/button/button.directive.spec.ts
+++ b/libs/shared/src/lib/ui-kit/button/button.directive.spec.ts
@@ -1,0 +1,132 @@
+import { Component, signal, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ButtonDirective } from './button.directive';
+
+describe('ButtonDirective', () => {
+  async function render<T>(component: Type<T>): Promise<ComponentFixture<T>> {
+    await TestBed.configureTestingModule({
+      imports: [component],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(component);
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  it('keeps native type and disabled on a button host', async () => {
+    @Component({
+      template: `<button libButton type="submit" disabled>Save</button>`,
+      imports: [ButtonDirective],
+    })
+    class Host {}
+
+    const fixture = await render(Host);
+    const button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+
+    expect(button.type).toBe('submit');
+    expect(button.disabled).toBe(true);
+    expect(button.textContent).toContain('Save');
+  });
+
+  it('works on a native link and projects icon markup', async () => {
+    @Component({
+      template: `
+        <a libButton href="/catalog">
+          <i class="pi pi-shopping-cart" aria-hidden="true"></i>
+          Catalog
+        </a>
+      `,
+      imports: [ButtonDirective],
+    })
+    class Host {}
+
+    const fixture = await render(Host);
+    const link = fixture.nativeElement.querySelector('a') as HTMLAnchorElement;
+
+    expect(link.getAttribute('href')).toBe('/catalog');
+    expect(link.textContent).toContain('Catalog');
+    expect(link.querySelector('.pi-shopping-cart')).not.toBeNull();
+  });
+
+  it('marks the control busy when loading and does not emit click', async () => {
+    const clicked = vi.fn();
+
+    @Component({
+      template: `<button libButton type="button" [loading]="loading()" (click)="onClick()">Pay</button>`,
+      imports: [ButtonDirective],
+    })
+    class Host {
+      readonly loading = signal(true);
+      onClick = clicked;
+    }
+
+    const fixture = await render(Host);
+    const button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+
+    expect(button.getAttribute('aria-busy')).toBe('true');
+    expect(button.disabled).toBe(true);
+
+    button.click();
+    await fixture.whenStable();
+    expect(clicked).not.toHaveBeenCalled();
+  });
+
+  it('restores a previously enabled button when loading ends', async () => {
+    @Component({
+      template: `<button libButton type="button" [loading]="loading()">Pay</button>`,
+      imports: [ButtonDirective],
+    })
+    class Host {
+      readonly loading = signal(true);
+    }
+
+    const fixture = await render(Host);
+    const button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+
+    fixture.componentInstance.loading.set(false);
+    await fixture.whenStable();
+    expect(button.disabled).toBe(false);
+    expect(button.hasAttribute('aria-busy')).toBe(false);
+  });
+
+  it('does not enable a natively disabled button when loading ends', async () => {
+    @Component({
+      template: `<button libButton type="button" disabled [loading]="loading()">Pay</button>`,
+      imports: [ButtonDirective],
+    })
+    class Host {
+      readonly loading = signal(true);
+    }
+
+    const fixture = await render(Host);
+    fixture.componentInstance.loading.set(false);
+    await fixture.whenStable();
+
+    const button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  it('sets aria-disabled on an anchor while loading and blocks navigation', async () => {
+    const clicked = vi.fn();
+
+    @Component({
+      template: `<a libButton href="/pay" [loading]="true" (click)="onClick()">Pay</a>`,
+      imports: [ButtonDirective],
+    })
+    class Host {
+      onClick = clicked;
+    }
+
+    const fixture = await render(Host);
+    const link = fixture.nativeElement.querySelector('a') as HTMLAnchorElement;
+
+    expect(link.getAttribute('aria-disabled')).toBe('true');
+    expect(link.hasAttribute('disabled')).toBe(false);
+
+    link.click();
+    await fixture.whenStable();
+    expect(clicked).not.toHaveBeenCalled();
+  });
+});

--- a/libs/shared/src/lib/ui-kit/button/button.directive.ts
+++ b/libs/shared/src/lib/ui-kit/button/button.directive.ts
@@ -1,0 +1,90 @@
+import {
+  booleanAttribute,
+  DestroyRef,
+  Directive,
+  effect,
+  ElementRef,
+  inject,
+  input,
+} from '@angular/core';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+export type ButtonSize = 'sm' | 'md' | 'icon';
+
+@Directive({
+  selector: 'button[libButton], a[libButton]',
+  host: {
+    class:
+      'inline-flex items-center justify-center gap-2 font-medium rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+    '[class.bg-primary]': 'variant() === "primary"',
+    '[class.text-primary-foreground]': 'variant() === "primary"',
+    '[class.hover:bg-primary-800]': 'variant() === "primary"',
+    '[class.bg-surface-100]': 'variant() === "secondary"',
+    '[class.text-foreground]':
+      'variant() === "secondary" || variant() === "ghost"',
+    '[class.border]': 'variant() === "secondary"',
+    '[class.border-border]': 'variant() === "secondary"',
+    '[class.hover:bg-surface-200]': 'variant() === "secondary"',
+    '[class.bg-transparent]': 'variant() === "ghost"',
+    '[class.hover:bg-surface-100]': 'variant() === "ghost"',
+    '[class.bg-red-700]': 'variant() === "danger"',
+    '[class.text-white]': 'variant() === "danger"',
+    '[class.hover:bg-red-800]': 'variant() === "danger"',
+    '[class.h-8]': 'size() === "sm"',
+    '[class.px-3]': 'size() === "sm"',
+    '[class.text-xs]': 'size() === "sm"',
+    '[class.h-10]': 'size() === "md"',
+    '[class.px-4]': 'size() === "md"',
+    '[class.text-sm]': 'size() === "md"',
+    '[class.size-10]': 'size() === "icon"',
+    '[class.p-0]': 'size() === "icon"',
+    '[attr.aria-busy]': 'loading() ? "true" : null',
+    '[attr.aria-disabled]': 'anchorDisabled()',
+  },
+})
+export class ButtonDirective {
+  public readonly variant = input<ButtonVariant>('primary');
+  public readonly size = input<ButtonSize>('md');
+  public readonly loading = input(false, { transform: booleanAttribute });
+
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly destroyRef = inject(DestroyRef);
+  private disabledByLoading = false;
+
+  constructor() {
+    const el = this.host.nativeElement;
+    const guard = (event: Event) => {
+      if (!this.loading()) {
+        return;
+      }
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    };
+    el.addEventListener('click', guard, true);
+    this.destroyRef.onDestroy(() =>
+      el.removeEventListener('click', guard, true)
+    );
+
+    effect(() => {
+      const loading = this.loading();
+      if (!(el instanceof HTMLButtonElement)) {
+        return;
+      }
+      if (loading && !el.disabled) {
+        el.disabled = true;
+        this.disabledByLoading = true;
+      } else if (!loading && this.disabledByLoading) {
+        el.disabled = false;
+        this.disabledByLoading = false;
+      }
+    });
+  }
+
+  protected anchorDisabled(): string | null {
+    const el = this.host.nativeElement;
+    if (!(el instanceof HTMLAnchorElement)) {
+      return null;
+    }
+    return this.loading() ? 'true' : null;
+  }
+}

--- a/libs/shared/src/lib/ui-kit/checkbox/checkbox.directive.spec.ts
+++ b/libs/shared/src/lib/ui-kit/checkbox/checkbox.directive.spec.ts
@@ -1,0 +1,78 @@
+import { Component, signal, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormField, form } from '@angular/forms/signals';
+import { describe, expect, it } from 'vitest';
+
+import { CheckboxDirective } from './checkbox.directive';
+
+describe('CheckboxDirective', () => {
+  async function render<T>(component: Type<T>): Promise<ComponentFixture<T>> {
+    await TestBed.configureTestingModule({
+      imports: [component],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(component);
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  it('keeps a native checkbox role and disabled state', async () => {
+    @Component({
+      template: `<input libCheckbox type="checkbox" disabled aria-label="Subscribe" />`,
+      imports: [CheckboxDirective],
+    })
+    class Host {}
+
+    const fixture = await render(Host);
+    const checkbox = fixture.nativeElement.querySelector(
+      'input'
+    ) as HTMLInputElement;
+
+    expect(checkbox.type).toBe('checkbox');
+    expect(checkbox.disabled).toBe(true);
+    expect(checkbox.getAttribute('aria-label')).toBe('Subscribe');
+  });
+
+  it('writes through a reactive FormControl', async () => {
+    @Component({
+      template: `<input libCheckbox type="checkbox" [formControl]="control" aria-label="Subscribe" />`,
+      imports: [CheckboxDirective, ReactiveFormsModule],
+    })
+    class Host {
+      readonly control = new FormControl(false, { nonNullable: true });
+    }
+
+    const fixture = await render(Host);
+    const checkbox = fixture.nativeElement.querySelector(
+      'input'
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+
+    checkbox.click();
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.control.value).toBe(true);
+  });
+
+  it('writes through a signal form field', async () => {
+    @Component({
+      template: `<input libCheckbox type="checkbox" [formField]="prefs.subscribe" aria-label="Subscribe" />`,
+      imports: [CheckboxDirective, FormField],
+    })
+    class Host {
+      private readonly model = signal({ subscribe: false });
+      readonly prefs = form(this.model);
+    }
+
+    const fixture = await render(Host);
+    const checkbox = fixture.nativeElement.querySelector(
+      'input'
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+
+    checkbox.click();
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.prefs.subscribe().value()).toBe(true);
+  });
+});

--- a/libs/shared/src/lib/ui-kit/checkbox/checkbox.directive.ts
+++ b/libs/shared/src/lib/ui-kit/checkbox/checkbox.directive.ts
@@ -1,0 +1,13 @@
+import { Directive } from '@angular/core';
+
+import { FieldControlDirective } from '../field/field-control.directive';
+
+@Directive({
+  selector: 'input[libCheckbox]',
+  hostDirectives: [FieldControlDirective],
+  host: {
+    class:
+      'size-4 rounded-sm border-border accent-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 disabled:pointer-events-none',
+  },
+})
+export class CheckboxDirective {}

--- a/libs/shared/src/lib/ui-kit/field/field-control.directive.ts
+++ b/libs/shared/src/lib/ui-kit/field/field-control.directive.ts
@@ -1,0 +1,31 @@
+import { Directive, ElementRef, inject } from '@angular/core';
+
+import { FieldComponent } from './field.component';
+
+@Directive({
+  selector: '[libFieldControl]',
+  host: {
+    '[id]': 'hostId()',
+    '[attr.aria-describedby]': 'describedBy()',
+    '[attr.aria-invalid]': 'ariaInvalid()',
+  },
+})
+export class FieldControlDirective {
+  private readonly field = inject(FieldComponent, { optional: true });
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  protected hostId(): string {
+    return this.field?.resolvedId() ?? this.host.nativeElement.id;
+  }
+
+  protected describedBy(): string | null {
+    return this.field?.describedBy() ?? null;
+  }
+
+  protected ariaInvalid(): string | null {
+    if (!this.field?.error()) {
+      return null;
+    }
+    return 'true';
+  }
+}

--- a/libs/shared/src/lib/ui-kit/field/field.component.html
+++ b/libs/shared/src/lib/ui-kit/field/field.component.html
@@ -1,0 +1,17 @@
+<label
+  class="text-sm font-medium text-foreground"
+  [attr.for]="resolvedId()"
+>
+  {{ label() }}
+</label>
+<ng-content />
+@if (error(); as errorText) {
+  <p class="text-sm text-red-700" role="alert" [id]="errorId()">
+    {{ errorText }}
+  </p>
+}
+@if (hint(); as hintText) {
+  <p class="text-sm text-surface-500" [id]="hintId()">
+    {{ hintText }}
+  </p>
+}

--- a/libs/shared/src/lib/ui-kit/field/field.component.spec.ts
+++ b/libs/shared/src/lib/ui-kit/field/field.component.spec.ts
@@ -1,0 +1,77 @@
+import { Component, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+
+import { InputDirective } from '../input/input.directive';
+import { FieldComponent } from './field.component';
+
+describe('FieldComponent', () => {
+  async function render<T>(component: Type<T>): Promise<ComponentFixture<T>> {
+    await TestBed.configureTestingModule({
+      imports: [component],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(component);
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  it('associates a stacked label with the projected control', async () => {
+    @Component({
+      template: `
+        <lib-field label="Email" controlId="email">
+          <input libInput type="email" />
+        </lib-field>
+      `,
+      imports: [FieldComponent, InputDirective],
+    })
+    class Host {}
+
+    const fixture = await render(Host);
+    const label = fixture.nativeElement.querySelector('label') as HTMLLabelElement;
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+
+    expect(label.textContent?.trim()).toBe('Email');
+    expect(label.htmlFor).toBe('email');
+    expect(input.id).toBe('email');
+  });
+
+  it('associates an error with the control for assistive tech', async () => {
+    @Component({
+      template: `
+        <lib-field label="Email" controlId="email" error="Email is required">
+          <input libInput type="email" />
+        </lib-field>
+      `,
+      imports: [FieldComponent, InputDirective],
+    })
+    class Host {}
+
+    const fixture = await render(Host);
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+    const alert = fixture.nativeElement.querySelector('[role="alert"]') as HTMLElement;
+
+    expect(alert.textContent?.trim()).toBe('Email is required');
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+    expect(input.getAttribute('aria-describedby')).toBe(alert.id);
+  });
+
+  it('associates a hint when there is no error and ships no default copy', async () => {
+    @Component({
+      template: `
+        <lib-field label="Phone" controlId="phone" hint="Include country code">
+          <input libInput type="tel" />
+        </lib-field>
+      `,
+      imports: [FieldComponent, InputDirective],
+    })
+    class Host {}
+
+    const fixture = await render(Host);
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+    const hint = fixture.nativeElement.querySelector('#phone-hint') as HTMLElement;
+
+    expect(hint.textContent?.trim()).toBe('Include country code');
+    expect(input.getAttribute('aria-describedby')).toBe('phone-hint');
+    expect(fixture.nativeElement.querySelector('[role="alert"]')).toBeNull();
+  });
+});

--- a/libs/shared/src/lib/ui-kit/field/field.component.ts
+++ b/libs/shared/src/lib/ui-kit/field/field.component.ts
@@ -1,0 +1,43 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from '@angular/core';
+
+let nextFieldId = 0;
+
+@Component({
+  selector: 'lib-field',
+  templateUrl: './field.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'flex flex-col gap-1',
+  },
+})
+export class FieldComponent {
+  public readonly label = input.required<string>();
+  public readonly error = input<string | undefined>(undefined);
+  public readonly hint = input<string | undefined>(undefined);
+  public readonly controlId = input<string | undefined>(undefined);
+
+  private readonly autoId = `lib-field-${++nextFieldId}`;
+
+  public readonly resolvedId = computed(
+    () => this.controlId() ?? this.autoId
+  );
+
+  public readonly errorId = computed(() => `${this.resolvedId()}-error`);
+  public readonly hintId = computed(() => `${this.resolvedId()}-hint`);
+
+  public readonly describedBy = computed(() => {
+    const ids: string[] = [];
+    if (this.error()) {
+      ids.push(this.errorId());
+    }
+    if (this.hint()) {
+      ids.push(this.hintId());
+    }
+    return ids.length > 0 ? ids.join(' ') : null;
+  });
+}

--- a/libs/shared/src/lib/ui-kit/input/input.directive.spec.ts
+++ b/libs/shared/src/lib/ui-kit/input/input.directive.spec.ts
@@ -1,0 +1,76 @@
+import { Component, signal, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormField, form } from '@angular/forms/signals';
+import { describe, expect, it } from 'vitest';
+
+import { InputDirective } from './input.directive';
+
+describe('InputDirective', () => {
+  async function render<T>(component: Type<T>): Promise<ComponentFixture<T>> {
+    await TestBed.configureTestingModule({
+      imports: [component],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(component);
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  it('keeps a native textbox role and disabled state', async () => {
+    @Component({
+      template: `<input libInput type="email" disabled aria-label="Email" />`,
+      imports: [InputDirective],
+    })
+    class Host {}
+
+    const fixture = await render(Host);
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+
+    expect(input.type).toBe('email');
+    expect(input.disabled).toBe(true);
+    expect(input.getAttribute('aria-label')).toBe('Email');
+  });
+
+  it('writes through a reactive FormControl', async () => {
+    @Component({
+      template: `<input libInput [formControl]="control" aria-label="Name" />`,
+      imports: [InputDirective, ReactiveFormsModule],
+    })
+    class Host {
+      readonly control = new FormControl('Ada', { nonNullable: true });
+    }
+
+    const fixture = await render(Host);
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+    expect(input.value).toBe('Ada');
+
+    input.value = 'Grace';
+    input.dispatchEvent(new Event('input'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.control.value).toBe('Grace');
+  });
+
+  it('writes through a signal form field', async () => {
+    @Component({
+      template: `<input libInput [formField]="login.email" aria-label="Email" />`,
+      imports: [InputDirective, FormField],
+    })
+    class Host {
+      private readonly model = signal({ email: 'ada@example.com' });
+      readonly login = form(this.model);
+    }
+
+    const fixture = await render(Host);
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement;
+    expect(input.value).toBe('ada@example.com');
+
+    input.value = 'grace@example.com';
+    input.dispatchEvent(new Event('input'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.login.email().value()).toBe(
+      'grace@example.com'
+    );
+  });
+});

--- a/libs/shared/src/lib/ui-kit/input/input.directive.ts
+++ b/libs/shared/src/lib/ui-kit/input/input.directive.ts
@@ -1,0 +1,13 @@
+import { Directive } from '@angular/core';
+
+import { FieldControlDirective } from '../field/field-control.directive';
+
+@Directive({
+  selector: 'input[libInput]',
+  hostDirectives: [FieldControlDirective],
+  host: {
+    class:
+      'w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 disabled:pointer-events-none',
+  },
+})
+export class InputDirective {}

--- a/libs/shared/src/lib/ui-kit/select/select.directive.spec.ts
+++ b/libs/shared/src/lib/ui-kit/select/select.directive.spec.ts
@@ -1,0 +1,88 @@
+import { Component, signal, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormField, form } from '@angular/forms/signals';
+import { describe, expect, it } from 'vitest';
+
+import { SelectDirective } from './select.directive';
+
+describe('SelectDirective', () => {
+  async function render<T>(component: Type<T>): Promise<ComponentFixture<T>> {
+    await TestBed.configureTestingModule({
+      imports: [component],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(component);
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  it('keeps native disabled on a combobox', async () => {
+    @Component({
+      template: `
+        <select libSelect disabled aria-label="Sort">
+          <option value="name">Name</option>
+        </select>
+      `,
+      imports: [SelectDirective],
+    })
+    class Host {}
+
+    const fixture = await render(Host);
+    const select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+
+    expect(select.disabled).toBe(true);
+    expect(select.getAttribute('aria-label')).toBe('Sort');
+  });
+
+  it('writes through a reactive FormControl', async () => {
+    @Component({
+      template: `
+        <select libSelect [formControl]="control" aria-label="Sort">
+          <option value="name">Name</option>
+          <option value="price">Price</option>
+        </select>
+      `,
+      imports: [SelectDirective, ReactiveFormsModule],
+    })
+    class Host {
+      readonly control = new FormControl('name', { nonNullable: true });
+    }
+
+    const fixture = await render(Host);
+    const select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+    expect(select.value).toBe('name');
+
+    select.value = 'price';
+    select.dispatchEvent(new Event('change'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.control.value).toBe('price');
+  });
+
+  it('writes through a signal form field', async () => {
+    @Component({
+      template: `
+        <select libSelect [formField]="filters.sort" aria-label="Sort">
+          <option value="name">Name</option>
+          <option value="price">Price</option>
+        </select>
+      `,
+      imports: [SelectDirective, FormField],
+    })
+    class Host {
+      private readonly model = signal({ sort: 'name' });
+      readonly filters = form(this.model);
+    }
+
+    const fixture = await render(Host);
+    const select = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+    expect(select.value).toBe('name');
+
+    select.value = 'price';
+    select.dispatchEvent(new Event('input', { bubbles: true }));
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.filters.sort().value()).toBe('price');
+  });
+});

--- a/libs/shared/src/lib/ui-kit/select/select.directive.ts
+++ b/libs/shared/src/lib/ui-kit/select/select.directive.ts
@@ -1,0 +1,13 @@
+import { Directive } from '@angular/core';
+
+import { FieldControlDirective } from '../field/field-control.directive';
+
+@Directive({
+  selector: 'select[libSelect]',
+  hostDirectives: [FieldControlDirective],
+  host: {
+    class:
+      'w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 disabled:pointer-events-none',
+  },
+})
+export class SelectDirective {}

--- a/libs/shared/src/public-api.ts
+++ b/libs/shared/src/public-api.ts
@@ -17,6 +17,16 @@ export {
   CardBodyDescriptionTemplateDirective,
 } from './lib/ui-kit/card/body/card-body/card-body.component';
 export { PaginatorComponent } from './lib/ui-kit/paginator/paginator.component';
+export {
+  ButtonDirective,
+  type ButtonSize,
+  type ButtonVariant,
+} from './lib/ui-kit/button/button.directive';
+export { InputDirective } from './lib/ui-kit/input/input.directive';
+export { SelectDirective } from './lib/ui-kit/select/select.directive';
+export { CheckboxDirective } from './lib/ui-kit/checkbox/checkbox.directive';
+export { FieldComponent } from './lib/ui-kit/field/field.component';
+export { FieldControlDirective } from './lib/ui-kit/field/field-control.directive';
 export { AppHttpAgent } from './lib/util-copilotkit/app-http-agent';
 export {
   initAgentStore,

--- a/libs/shared/tsconfig.spec.json
+++ b/libs/shared/tsconfig.spec.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "declaration": true,
     "types": [
       "vitest/globals",
       "vitest/importMeta",


### PR DESCRIPTION
Ship Button, Input, Select, Checkbox, and Field as dump primitives so later storefront screens can style native controls without PrimeNG. Native type/disabled stay platform behaviour; Field associates errors with the control; Vitest covers roles, labels, loading, and reactive/signal forms.

Decisions: form leaves are directives on native hosts; libFieldControl is on the barrel because ng-packagr requires hostDirectives to be public; shared lint matches auth-web lib-/libButton rules with overrides for existing app- kit/assistant files until #68.

Files: ui-kit button/input/select/checkbox/field, public-api, eslint selector rules, tsconfig.spec declaration for typecheck.

Notes: No storefront caller cutover. Quantity control and price-range stay outside the kit.