### PR TITLE
RALPH: kit structure widgets in shared (#68, PRD #65)

### DIFF
--- a/libs/shared/eslint.config.mjs
+++ b/libs/shared/eslint.config.mjs
@@ -27,13 +27,7 @@ export default [
   },
   {
     // Pre-existing app- selectors stay until later kit/assistant tickets.
-    files: [
-      '**/ui-kit/card/**/*.ts',
-      '**/ui-kit/image/**/*.ts',
-      '**/ui-kit/paginator/**/*.ts',
-      '**/ui-assistant/**/*.ts',
-      '**/util-copilotkit/**/*.ts',
-    ],
+    files: ['**/ui-assistant/**/*.ts', '**/util-copilotkit/**/*.ts'],
     rules: {
       '@angular-eslint/directive-selector': 'off',
       '@angular-eslint/component-selector': 'off',

--- a/libs/shared/src/lib/ui-kit/card/body/card-body/card-body.component.html
+++ b/libs/shared/src/lib/ui-kit/card/body/card-body/card-body.component.html
@@ -1,8 +1,8 @@
-<div class="md:px-2 lg:px-4 xl:px-6 lg:pt-6 pt-5 flex gap-4 flex-col">
-  <h4 class="text-lg font-medium">
+<div class="flex flex-col gap-2 p-4">
+  <h4 class="text-lg font-medium text-foreground">
     <ng-container [ngTemplateOutlet]="cardTitle()"></ng-container>
   </h4>
-  <h5 class="text-xl font-normal">
+  <h5 class="text-sm font-normal text-surface-500">
     <ng-container [ngTemplateOutlet]="cardDescription()"></ng-container>
   </h5>
 </div>

--- a/libs/shared/src/lib/ui-kit/card/body/card-body/card-body.component.ts
+++ b/libs/shared/src/lib/ui-kit/card/body/card-body/card-body.component.ts
@@ -8,17 +8,17 @@ import {
 import { NgTemplateOutlet } from '@angular/common';
 
 @Directive({
-  selector: 'ng-template[cardBodyTitle]',
+  selector: 'ng-template[libCardBodyTitle]',
 })
 export class CardBodyTitleTemplateDirective {}
 
 @Directive({
-  selector: 'ng-template[cardBodyDescription]',
+  selector: 'ng-template[libCardBodyDescription]',
 })
 export class CardBodyDescriptionTemplateDirective {}
 
 @Component({
-  selector: 'app-card-body',
+  selector: 'lib-card-body',
   templateUrl: './card-body.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgTemplateOutlet],
@@ -28,12 +28,12 @@ export class CardBodyComponent {
     CardBodyTitleTemplateDirective,
     {
       read: TemplateRef,
-    }
+    },
   );
   protected readonly cardDescription = contentChild.required(
     CardBodyDescriptionTemplateDirective,
     {
       read: TemplateRef,
-    }
+    },
   );
 }

--- a/libs/shared/src/lib/ui-kit/card/card.component.html
+++ b/libs/shared/src/lib/ui-kit/card/card.component.html
@@ -6,10 +6,6 @@
   [ngTemplateOutlet]="cardBodyTemplate() || defaultCardBodyTemplate"
 ></ng-container>
 
-<ng-template #defaultCardHeaderTemplate>
-  <div>card header</div>
-</ng-template>
+<ng-template #defaultCardHeaderTemplate></ng-template>
 
-<ng-template #defaultCardBodyTemplate>
-  <div>card body</div>
-</ng-template>
+<ng-template #defaultCardBodyTemplate></ng-template>

--- a/libs/shared/src/lib/ui-kit/card/card.component.spec.ts
+++ b/libs/shared/src/lib/ui-kit/card/card.component.spec.ts
@@ -1,0 +1,75 @@
+import { Component, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+
+import {
+  CardBodyComponent,
+  CardBodyDescriptionTemplateDirective,
+  CardBodyTitleTemplateDirective,
+} from './body/card-body/card-body.component';
+import {
+  CardComponent,
+  CardBodyTemplateDirective,
+  CardHeaderTemplateDirective,
+} from './card.component';
+import { CardHeaderContentTemplateDirective } from './header/card-header-content-template.directive';
+import {
+  CardActionsTemplateDirective,
+  CardHeaderComponent,
+} from './header/card-header/card-header.component';
+
+describe('CardComponent', () => {
+  async function render<T>(component: Type<T>): Promise<ComponentFixture<T>> {
+    await TestBed.configureTestingModule({
+      imports: [component],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(component);
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  it('keeps header and body composition without default English copy', async () => {
+    @Component({
+      template: `
+        <lib-card>
+          <ng-template libCardHeader>
+            <lib-card-header>
+              <ng-template libCardHeaderContent>Product photo</ng-template>
+              <ng-template libCardHeaderActions>
+                <button type="button">Favorite</button>
+              </ng-template>
+            </lib-card-header>
+          </ng-template>
+          <ng-template libCardBody>
+            <lib-card-body>
+              <ng-template libCardBodyTitle>Espresso</ng-template>
+              <ng-template libCardBodyDescription>Dark roast</ng-template>
+            </lib-card-body>
+          </ng-template>
+        </lib-card>
+      `,
+      imports: [
+        CardComponent,
+        CardHeaderTemplateDirective,
+        CardBodyTemplateDirective,
+        CardHeaderComponent,
+        CardHeaderContentTemplateDirective,
+        CardActionsTemplateDirective,
+        CardBodyComponent,
+        CardBodyTitleTemplateDirective,
+        CardBodyDescriptionTemplateDirective,
+      ],
+    })
+    class Host {}
+
+    const fixture = await render(Host);
+    const text = fixture.nativeElement.textContent as string;
+
+    expect(text).toContain('Product photo');
+    expect(text).toContain('Favorite');
+    expect(text).toContain('Espresso');
+    expect(text).toContain('Dark roast');
+    expect(text).not.toContain('card header');
+    expect(text).not.toContain('card body');
+  });
+});

--- a/libs/shared/src/lib/ui-kit/card/card.component.ts
+++ b/libs/shared/src/lib/ui-kit/card/card.component.ts
@@ -8,22 +8,23 @@ import {
 import { NgTemplateOutlet } from '@angular/common';
 
 @Directive({
-  selector: 'ng-template[cardBody]',
+  selector: 'ng-template[libCardBody]',
 })
 export class CardBodyTemplateDirective {}
 
 @Directive({
-  selector: 'ng-template[cardHeader]',
+  selector: 'ng-template[libCardHeader]',
 })
 export class CardHeaderTemplateDirective {}
 
 @Component({
-  selector: 'app-card',
+  selector: 'lib-card',
   templateUrl: './card.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgTemplateOutlet],
   host: {
-    class: 'relative w-full',
+    class:
+      'relative block w-full overflow-hidden rounded-md border border-border bg-surface text-foreground shadow-sm',
   },
 })
 export class CardComponent {
@@ -31,12 +32,12 @@ export class CardComponent {
     CardHeaderTemplateDirective,
     {
       read: TemplateRef,
-    }
+    },
   );
   protected readonly cardBodyTemplate = contentChild(
     CardBodyTemplateDirective,
     {
       read: TemplateRef,
-    }
+    },
   );
 }

--- a/libs/shared/src/lib/ui-kit/card/header/card-header-content-template.directive.ts
+++ b/libs/shared/src/lib/ui-kit/card/header/card-header-content-template.directive.ts
@@ -1,6 +1,6 @@
 import { Directive } from '@angular/core';
 
 @Directive({
-  selector: 'ng-template[cardHeaderContent]',
+  selector: 'ng-template[libCardHeaderContent]',
 })
 export class CardHeaderContentTemplateDirective {}

--- a/libs/shared/src/lib/ui-kit/card/header/card-header/card-header.component.html
+++ b/libs/shared/src/lib/ui-kit/card/header/card-header/card-header.component.html
@@ -2,15 +2,15 @@
   <ng-container [ngTemplateOutlet]="cardHeaderContentTemplate()"></ng-container>
 
   @if (cardHeaderActions()) {
-  <div
-    class="absolute"
-    [class.top-0]="actionsPlacement() === 'top'"
-    [class.top-[50%]]="actionsPlacement() === 'center'"
-    [class.bottom-0]="actionsPlacement() === 'bottom'"
-    [class.left-0]="actionsPosition() === 'left'"
-    [class.right-0]="actionsPosition() === 'right'"
-  >
-    <ng-container [ngTemplateOutlet]="cardHeaderActions()"></ng-container>
-  </div>
+    <div
+      class="absolute"
+      [class.top-0]="actionsPlacement() === 'top'"
+      [class.top-[50%]]="actionsPlacement() === 'center'"
+      [class.bottom-0]="actionsPlacement() === 'bottom'"
+      [class.left-0]="actionsPosition() === 'left'"
+      [class.right-0]="actionsPosition() === 'right'"
+    >
+      <ng-container [ngTemplateOutlet]="cardHeaderActions()"></ng-container>
+    </div>
   }
 </div>

--- a/libs/shared/src/lib/ui-kit/card/header/card-header/card-header.component.ts
+++ b/libs/shared/src/lib/ui-kit/card/header/card-header/card-header.component.ts
@@ -11,31 +11,31 @@ import { NgTemplateOutlet } from '@angular/common';
 import { CardHeaderContentTemplateDirective } from '../card-header-content-template.directive';
 
 @Directive({
-  selector: 'ng-template[cardHeaderActions]',
+  selector: 'ng-template[libCardHeaderActions]',
 })
 export class CardActionsTemplateDirective {}
 
 @Component({
-  selector: 'app-card-header',
+  selector: 'lib-card-header',
   templateUrl: './card-header.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgTemplateOutlet],
 })
 export class CardHeaderComponent {
   public readonly actionsPlacement = input<'top' | 'bottom' | 'center'>(
-    'bottom'
+    'bottom',
   );
   public readonly actionsPosition = input<'left' | 'right' | 'center'>('right');
   protected readonly cardHeaderContentTemplate = contentChild.required(
     CardHeaderContentTemplateDirective,
     {
       read: TemplateRef,
-    }
+    },
   );
   protected readonly cardHeaderActions = contentChild(
     CardActionsTemplateDirective,
     {
       read: TemplateRef,
-    }
+    },
   );
 }

--- a/libs/shared/src/lib/ui-kit/drawer/drawer.component.html
+++ b/libs/shared/src/lib/ui-kit/drawer/drawer.component.html
@@ -1,0 +1,15 @@
+<dialog
+  #panel
+  role="dialog"
+  tabindex="-1"
+  class="m-0 ml-auto h-full max-h-screen w-full max-w-md border-0 bg-surface p-4 text-foreground shadow-lg open:flex open:flex-col"
+  [attr.aria-modal]="open() ? 'true' : null"
+  (close)="onDialogClose()"
+  (cancel)="onEscape($event)"
+  (keydown.escape)="onEscape($event)"
+  (click)="onBackdropClick($event)"
+>
+  <div class="flex min-h-0 flex-1 flex-col" (click)="$event.stopPropagation()">
+    <ng-content />
+  </div>
+</dialog>

--- a/libs/shared/src/lib/ui-kit/drawer/drawer.component.scss
+++ b/libs/shared/src/lib/ui-kit/drawer/drawer.component.scss
@@ -1,0 +1,3 @@
+dialog::backdrop {
+  background: rgb(0 0 0 / 0.4);
+}

--- a/libs/shared/src/lib/ui-kit/drawer/drawer.component.spec.ts
+++ b/libs/shared/src/lib/ui-kit/drawer/drawer.component.spec.ts
@@ -1,0 +1,76 @@
+import { Component, signal, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+
+import { DrawerComponent } from './drawer.component';
+
+describe('DrawerComponent', () => {
+  async function render<T>(component: Type<T>): Promise<ComponentFixture<T>> {
+    await TestBed.configureTestingModule({
+      imports: [component],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(component);
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  it('binds open two-way to a native dialog and moves focus inside', async () => {
+    @Component({
+      template: `
+        <button type="button" id="opener">Open cart</button>
+        <lib-drawer [(open)]="open">
+          <button type="button">Inside</button>
+        </lib-drawer>
+      `,
+      imports: [DrawerComponent],
+    })
+    class Host {
+      readonly open = signal(false);
+    }
+
+    const fixture = await render(Host);
+    const opener = fixture.nativeElement.querySelector(
+      '#opener',
+    ) as HTMLButtonElement;
+    opener.focus();
+    expect(document.activeElement).toBe(opener);
+
+    fixture.componentInstance.open.set(true);
+    await fixture.whenStable();
+
+    const dialog = fixture.nativeElement.querySelector(
+      'dialog',
+    ) as HTMLDialogElement;
+    expect(dialog.open).toBe(true);
+    expect(dialog.getAttribute('role')).toBe('dialog');
+    expect(dialog.contains(document.activeElement)).toBe(true);
+  });
+
+  it('closes on Escape and writes open back to false', async () => {
+    @Component({
+      template: `
+        <lib-drawer [(open)]="open">
+          <button type="button">Inside</button>
+        </lib-drawer>
+      `,
+      imports: [DrawerComponent],
+    })
+    class Host {
+      readonly open = signal(true);
+    }
+
+    const fixture = await render(Host);
+    const dialog = fixture.nativeElement.querySelector(
+      'dialog',
+    ) as HTMLDialogElement;
+    expect(dialog.open).toBe(true);
+
+    dialog.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    );
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.open()).toBe(false);
+    expect(dialog.open).toBe(false);
+  });
+});

--- a/libs/shared/src/lib/ui-kit/drawer/drawer.component.ts
+++ b/libs/shared/src/lib/ui-kit/drawer/drawer.component.ts
@@ -1,0 +1,75 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  ElementRef,
+  model,
+  viewChild,
+} from '@angular/core';
+
+@Component({
+  selector: 'lib-drawer',
+  templateUrl: './drawer.component.html',
+  styleUrl: './drawer.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'contents',
+  },
+})
+export class DrawerComponent {
+  public readonly open = model(false);
+
+  private readonly panel = viewChild<ElementRef<HTMLDialogElement>>('panel');
+  private returnFocusTo: HTMLElement | null = null;
+
+  constructor() {
+    effect(() => {
+      const panel = this.panel();
+      if (!panel) {
+        return;
+      }
+      const dialog = panel.nativeElement;
+      const shouldOpen = this.open();
+      if (shouldOpen && !dialog.open) {
+        this.rememberFocus();
+        dialog.showModal();
+        if (!dialog.contains(document.activeElement)) {
+          dialog.focus();
+        }
+      } else if (!shouldOpen && dialog.open) {
+        dialog.close();
+        this.restoreFocus();
+      }
+    });
+  }
+
+  protected onDialogClose(): void {
+    if (this.open()) {
+      this.open.set(false);
+    }
+    this.restoreFocus();
+  }
+
+  protected onEscape(event: Event): void {
+    event.preventDefault();
+    this.open.set(false);
+  }
+
+  protected onBackdropClick(event: MouseEvent): void {
+    if (event.target === event.currentTarget) {
+      this.open.set(false);
+    }
+  }
+
+  private rememberFocus(): void {
+    this.returnFocusTo =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+  }
+
+  private restoreFocus(): void {
+    this.returnFocusTo?.focus();
+    this.returnFocusTo = null;
+  }
+}

--- a/libs/shared/src/lib/ui-kit/image/image.component.html
+++ b/libs/shared/src/lib/ui-kit/image/image.component.html
@@ -1,4 +1,5 @@
 <img
+  class="rounded-md object-cover"
   [ngSrc]="image().path"
   [priority]="image().priority"
   [fill]="image().fill"

--- a/libs/shared/src/lib/ui-kit/image/image.component.spec.ts
+++ b/libs/shared/src/lib/ui-kit/image/image.component.spec.ts
@@ -1,0 +1,44 @@
+import { Component, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+
+import { ImageComponent } from './image.component';
+
+describe('ImageComponent', () => {
+  async function render<T>(component: Type<T>): Promise<ComponentFixture<T>> {
+    await TestBed.configureTestingModule({
+      imports: [component],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(component);
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  it('renders the provided image path on a native img', async () => {
+    @Component({
+      template: `
+        <lib-image
+          [image]="{
+            path: '/assets/product.png',
+            priority: true,
+            fill: false,
+            width: 320,
+            height: 240,
+          }"
+        />
+      `,
+      imports: [ImageComponent],
+    })
+    class Host {}
+
+    const fixture = await render(Host);
+    const img = fixture.nativeElement.querySelector('img') as HTMLImageElement;
+
+    expect(img).not.toBeNull();
+    expect(img.getAttribute('ng-src') ?? img.getAttribute('src')).toContain(
+      '/assets/product.png',
+    );
+    expect(img.width).toBe(320);
+    expect(img.height).toBe(240);
+  });
+});

--- a/libs/shared/src/lib/ui-kit/image/image.component.ts
+++ b/libs/shared/src/lib/ui-kit/image/image.component.ts
@@ -4,10 +4,15 @@ import { NgOptimizedImage } from '@angular/common';
 import { ImageViewModel } from './image.view.model';
 
 @Component({
-  selector: 'app-image',
+  selector: 'lib-image',
   templateUrl: './image.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgOptimizedImage],
+  host: {
+    class: 'relative inline-block overflow-hidden rounded-md bg-surface-100',
+    '[class.block]': 'image().fill',
+    '[class.w-full]': 'image().fill',
+  },
 })
 export class ImageComponent {
   public readonly image = input.required<ImageViewModel>();

--- a/libs/shared/src/lib/ui-kit/inline-message/inline-message.component.html
+++ b/libs/shared/src/lib/ui-kit/inline-message/inline-message.component.html
@@ -1,0 +1,1 @@
+<ng-content />

--- a/libs/shared/src/lib/ui-kit/inline-message/inline-message.component.spec.ts
+++ b/libs/shared/src/lib/ui-kit/inline-message/inline-message.component.spec.ts
@@ -1,0 +1,53 @@
+import { Component, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+
+import { InlineMessageComponent } from './inline-message.component';
+
+describe('InlineMessageComponent', () => {
+  async function render<T>(component: Type<T>): Promise<ComponentFixture<T>> {
+    await TestBed.configureTestingModule({
+      imports: [component],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(component);
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  it('projects its body as an alert when variant is error', async () => {
+    @Component({
+      template: `<lib-inline-message variant="error"
+        >Place order failed</lib-inline-message
+      >`,
+      imports: [InlineMessageComponent],
+    })
+    class Host {}
+
+    const fixture = await render(Host);
+    const message = fixture.nativeElement.querySelector(
+      '[role="alert"]',
+    ) as HTMLElement;
+
+    expect(message.textContent?.trim()).toBe('Place order failed');
+  });
+
+  it('projects its body as status for warning and info', async () => {
+    @Component({
+      template: `
+        <lib-inline-message variant="warning">Low stock</lib-inline-message>
+        <lib-inline-message variant="info">Ships tomorrow</lib-inline-message>
+      `,
+      imports: [InlineMessageComponent],
+    })
+    class Host {}
+
+    const fixture = await render(Host);
+    const statuses = fixture.nativeElement.querySelectorAll(
+      '[role="status"]',
+    ) as NodeListOf<HTMLElement>;
+
+    expect(statuses).toHaveLength(2);
+    expect(statuses[0]?.textContent?.trim()).toBe('Low stock');
+    expect(statuses[1]?.textContent?.trim()).toBe('Ships tomorrow');
+  });
+});

--- a/libs/shared/src/lib/ui-kit/inline-message/inline-message.component.ts
+++ b/libs/shared/src/lib/ui-kit/inline-message/inline-message.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+export type InlineMessageVariant = 'error' | 'warning' | 'info';
+
+@Component({
+  selector: 'lib-inline-message',
+  templateUrl: './inline-message.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'block rounded-md border px-3 py-2 text-sm',
+    '[class.border-red-700]': 'variant() === "error"',
+    '[class.bg-red-50]': 'variant() === "error"',
+    '[class.text-red-700]': 'variant() === "error"',
+    '[class.border-amber-600]': 'variant() === "warning"',
+    '[class.bg-amber-50]': 'variant() === "warning"',
+    '[class.text-amber-800]': 'variant() === "warning"',
+    '[class.border-border]': 'variant() === "info"',
+    '[class.bg-surface-50]': 'variant() === "info"',
+    '[class.text-foreground]': 'variant() === "info"',
+    '[attr.role]': 'variant() === "error" ? "alert" : "status"',
+  },
+})
+export class InlineMessageComponent {
+  public readonly variant = input<InlineMessageVariant>('info');
+}

--- a/libs/shared/src/lib/ui-kit/paginator/paginator.component.html
+++ b/libs/shared/src/lib/ui-kit/paginator/paginator.component.html
@@ -1,9 +1,32 @@
-<div class="card flex justify-center">
-  <p-paginator
-    (onPageChange)="onPageChange($event)"
-    [first]="first()"
-    [rows]="rows()"
-    [totalRecords]="totalRecords()"
-    [rowsPerPageOptions]="rowsPerPageOptions()"
-  />
-</div>
+<button
+  libButton
+  type="button"
+  variant="ghost"
+  size="icon"
+  [attr.aria-label]="previousLabel()"
+  [disabled]="isFirstPage()"
+  (click)="goTo(page() - 1)"
+>
+  <i class="pi pi-chevron-left" aria-hidden="true"></i>
+</button>
+<select
+  libSelect
+  [attr.aria-label]="pageSizeLabel()"
+  [value]="pageSize()"
+  (change)="onPageSizeChange($event)"
+>
+  @for (size of pageSizeOptions(); track size) {
+    <option [value]="size" [selected]="size === pageSize()">{{ size }}</option>
+  }
+</select>
+<button
+  libButton
+  type="button"
+  variant="ghost"
+  size="icon"
+  [attr.aria-label]="nextLabel()"
+  [disabled]="isLastPage()"
+  (click)="goTo(page() + 1)"
+>
+  <i class="pi pi-chevron-right" aria-hidden="true"></i>
+</button>

--- a/libs/shared/src/lib/ui-kit/paginator/paginator.component.spec.ts
+++ b/libs/shared/src/lib/ui-kit/paginator/paginator.component.spec.ts
@@ -1,0 +1,110 @@
+import { Component, signal, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PaginatorComponent } from './paginator.component';
+
+describe('PaginatorComponent', () => {
+  async function render<T>(component: Type<T>): Promise<ComponentFixture<T>> {
+    await TestBed.configureTestingModule({
+      imports: [component],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(component);
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  it('emits pageChange from previous, next, and page-size using required accessible names', async () => {
+    const onPageChange = vi.fn();
+
+    @Component({
+      template: `
+        <lib-paginator
+          [page]="page()"
+          [pageSize]="pageSize()"
+          [total]="48"
+          [pageSizeOptions]="[12, 24, 48]"
+          previousLabel="Previous page"
+          nextLabel="Next page"
+          pageSizeLabel="Items per page"
+          (pageChange)="onPageChange($event)"
+        />
+      `,
+      imports: [PaginatorComponent],
+    })
+    class Host {
+      readonly page = signal(2);
+      readonly pageSize = signal(12);
+      onPageChange = onPageChange;
+    }
+
+    const fixture = await render(Host);
+    const previous = fixture.nativeElement.querySelector(
+      '[aria-label="Previous page"]',
+    ) as HTMLButtonElement;
+    const next = fixture.nativeElement.querySelector(
+      '[aria-label="Next page"]',
+    ) as HTMLButtonElement;
+    const pageSize = fixture.nativeElement.querySelector(
+      '[aria-label="Items per page"]',
+    ) as HTMLSelectElement;
+
+    expect(previous.tagName).toBe('BUTTON');
+    expect(next.tagName).toBe('BUTTON');
+    expect(pageSize.tagName).toBe('SELECT');
+
+    previous.click();
+    await fixture.whenStable();
+    expect(onPageChange).toHaveBeenCalledWith({ page: 1, pageSize: 12 });
+
+    onPageChange.mockClear();
+    next.click();
+    await fixture.whenStable();
+    expect(onPageChange).toHaveBeenCalledWith({ page: 3, pageSize: 12 });
+
+    onPageChange.mockClear();
+    pageSize.value = '24';
+    pageSize.dispatchEvent(new Event('change'));
+    await fixture.whenStable();
+    expect(onPageChange).toHaveBeenCalledWith({ page: 1, pageSize: 24 });
+  });
+
+  it('disables previous on the first page and next on the last page', async () => {
+    @Component({
+      template: `
+        <lib-paginator
+          [page]="page()"
+          [pageSize]="12"
+          [total]="24"
+          [pageSizeOptions]="[12]"
+          previousLabel="Previous page"
+          nextLabel="Next page"
+          pageSizeLabel="Items per page"
+        />
+      `,
+      imports: [PaginatorComponent],
+    })
+    class Host {
+      readonly page = signal(1);
+    }
+
+    const fixture = await render(Host);
+    const previous = () =>
+      fixture.nativeElement.querySelector(
+        '[aria-label="Previous page"]',
+      ) as HTMLButtonElement;
+    const next = () =>
+      fixture.nativeElement.querySelector(
+        '[aria-label="Next page"]',
+      ) as HTMLButtonElement;
+
+    expect(previous().disabled).toBe(true);
+    expect(next().disabled).toBe(false);
+
+    fixture.componentInstance.page.set(2);
+    await fixture.whenStable();
+
+    expect(previous().disabled).toBe(false);
+    expect(next().disabled).toBe(true);
+  });
+});

--- a/libs/shared/src/lib/ui-kit/paginator/paginator.component.ts
+++ b/libs/shared/src/lib/ui-kit/paginator/paginator.component.ts
@@ -1,35 +1,65 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   input,
-  linkedSignal,
   output,
-  signal,
 } from '@angular/core';
-import { PaginatorModule, PaginatorState } from 'primeng/paginator';
+
+import { ButtonDirective } from '../button/button.directive';
+import { SelectDirective } from '../select/select.directive';
+
+export type PaginatorPageChange = {
+  page: number;
+  pageSize: number;
+};
 
 @Component({
-  selector: 'app-paginator',
+  selector: 'lib-paginator',
   templateUrl: './paginator.component.html',
-  imports: [PaginatorModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonDirective, SelectDirective],
+  host: {
+    class: 'flex items-center justify-center gap-3',
+  },
 })
 export class PaginatorComponent {
-  public readonly totalRecords = input.required<number>();
-  public readonly rowsPerPageOptions = input.required<number[]>();
+  public readonly page = input.required<number>();
+  public readonly pageSize = input.required<number>();
+  public readonly total = input.required<number>();
+  public readonly pageSizeOptions = input.required<number[]>();
+  public readonly previousLabel = input.required<string>();
+  public readonly nextLabel = input.required<string>();
+  public readonly pageSizeLabel = input.required<string>();
 
-  public readonly changePage = output<{ page: number; limit: number }>();
+  public readonly pageChange = output<PaginatorPageChange>();
 
-  protected readonly first = signal<number>(0);
-  protected readonly rows = linkedSignal(() => this.rowsPerPageOptions()[0]);
+  protected readonly lastPage = computed(() => {
+    const size = this.pageSize();
+    if (size <= 0) {
+      return 1;
+    }
+    return Math.max(1, Math.ceil(this.total() / size));
+  });
 
-  public onPageChange(event: PaginatorState): void {
-    this.first.set(event.first ?? 0);
-    this.rows.set(event.rows ?? this.rowsPerPageOptions()[0]);
+  protected readonly isFirstPage = computed(() => this.page() <= 1);
+  protected readonly isLastPage = computed(
+    () => this.page() >= this.lastPage(),
+  );
 
-    this.changePage.emit({
-      page: event.page ? event.page + 1 : 1,
-      limit: event.rows ?? this.rowsPerPageOptions()[0],
-    });
+  protected goTo(page: number): void {
+    const nextPage = Math.min(this.lastPage(), Math.max(1, page));
+    if (nextPage === this.page()) {
+      return;
+    }
+    this.pageChange.emit({ page: nextPage, pageSize: this.pageSize() });
+  }
+
+  protected onPageSizeChange(event: Event): void {
+    const value = Number((event.target as HTMLSelectElement).value);
+    if (!Number.isFinite(value) || value === this.pageSize()) {
+      return;
+    }
+    this.pageChange.emit({ page: 1, pageSize: value });
   }
 }

--- a/libs/shared/src/lib/ui-kit/spinner/spinner.component.html
+++ b/libs/shared/src/lib/ui-kit/spinner/spinner.component.html
@@ -1,0 +1,20 @@
+<svg
+  class="size-6 animate-spin"
+  viewBox="0 0 24 24"
+  fill="none"
+  aria-hidden="true"
+>
+  <circle
+    class="opacity-25"
+    cx="12"
+    cy="12"
+    r="10"
+    stroke="currentColor"
+    stroke-width="4"
+  ></circle>
+  <path
+    class="opacity-75"
+    fill="currentColor"
+    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+  ></path>
+</svg>

--- a/libs/shared/src/lib/ui-kit/spinner/spinner.component.spec.ts
+++ b/libs/shared/src/lib/ui-kit/spinner/spinner.component.spec.ts
@@ -1,0 +1,34 @@
+import { Component, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+
+import { SpinnerComponent } from './spinner.component';
+
+describe('SpinnerComponent', () => {
+  async function render<T>(component: Type<T>): Promise<ComponentFixture<T>> {
+    await TestBed.configureTestingModule({
+      imports: [component],
+    }).compileComponents();
+    const fixture = TestBed.createComponent(component);
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  it('is an inline status with the caller-provided accessible name', async () => {
+    @Component({
+      template: `<lib-spinner ariaLabel="Loading catalog" />`,
+      imports: [SpinnerComponent],
+    })
+    class Host {}
+
+    const fixture = await render(Host);
+    const status = fixture.nativeElement.querySelector(
+      '[role="status"]',
+    ) as HTMLElement;
+
+    expect(status).not.toBeNull();
+    expect(status.getAttribute('aria-label')).toBe('Loading catalog');
+    expect(fixture.nativeElement.querySelector('dialog')).toBeNull();
+    expect(status.textContent?.trim()).toBe('');
+  });
+});

--- a/libs/shared/src/lib/ui-kit/spinner/spinner.component.ts
+++ b/libs/shared/src/lib/ui-kit/spinner/spinner.component.ts
@@ -1,0 +1,15 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+@Component({
+  selector: 'lib-spinner',
+  templateUrl: './spinner.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'inline-flex items-center justify-center text-primary',
+    role: 'status',
+    '[attr.aria-label]': 'ariaLabel()',
+  },
+})
+export class SpinnerComponent {
+  public readonly ariaLabel = input.required<string>();
+}

--- a/libs/shared/src/public-api.ts
+++ b/libs/shared/src/public-api.ts
@@ -16,7 +16,16 @@ export {
   CardBodyTitleTemplateDirective,
   CardBodyDescriptionTemplateDirective,
 } from './lib/ui-kit/card/body/card-body/card-body.component';
-export { PaginatorComponent } from './lib/ui-kit/paginator/paginator.component';
+export {
+  PaginatorComponent,
+  type PaginatorPageChange,
+} from './lib/ui-kit/paginator/paginator.component';
+export { DrawerComponent } from './lib/ui-kit/drawer/drawer.component';
+export { SpinnerComponent } from './lib/ui-kit/spinner/spinner.component';
+export {
+  InlineMessageComponent,
+  type InlineMessageVariant,
+} from './lib/ui-kit/inline-message/inline-message.component';
 export {
   ButtonDirective,
   type ButtonSize,

--- a/libs/shared/src/test-setup.ts
+++ b/libs/shared/src/test-setup.ts
@@ -3,3 +3,17 @@ import '@analogjs/vitest-angular/setup-snapshots';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 setupTestBed();
+
+// jsdom's HTMLDialogElement reflects `open` but does not implement showModal/close.
+if (
+  typeof HTMLDialogElement !== 'undefined' &&
+  typeof HTMLDialogElement.prototype.showModal !== 'function'
+) {
+  HTMLDialogElement.prototype.showModal = function (this: HTMLDialogElement) {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function (this: HTMLDialogElement) {
+    this.open = false;
+    this.dispatchEvent(new Event('close'));
+  };
+}


### PR DESCRIPTION
Ship Drawer, Spinner, Paginator, InlineMessage, and restyle Card/Image so Catalog pagination, the Cart drawer, loading states, and Checkout errors have dump primitives to bind to.

Decisions: Drawer is a native dialog with two-way open and no CDK; Paginator is fully controlled (page/pageSize/total/pageChange) with required a11y names and libButton/libSelect; Spinner and paginator copy stay caller-provided; Card/Image take the lib- prefix and token restyle.

Files: ui-kit drawer/spinner/paginator/inline-message/card/image, public-api, eslint selector overrides, test-setup dialog polyfill.

Notes: No storefront caller cutover. Quantity control and price-range stay outside the kit. v1 still has no Dialog, Tabs, Tooltip, Toast, Fluid, or custom listbox Select.