### PR TITLE
RALPH: kit ButtonDirective hover on semantic tokens (#79, PRD #77)

### DIFF
--- a/libs/shared/src/lib/ui-kit/button/button.directive.spec.ts
+++ b/libs/shared/src/lib/ui-kit/button/button.directive.spec.ts
@@ -130,4 +130,38 @@ describe('ButtonDirective', () => {
     await fixture.whenStable();
     expect(clicked).not.toHaveBeenCalled();
   });
+
+  it('binds variant hover to semantic tokens, not primary-800 or light-absolute surface steps', async () => {
+    @Component({
+      template: `
+        <button libButton type="button">Primary</button>
+        <button libButton type="button" variant="secondary">Secondary</button>
+        <button libButton type="button" variant="ghost">Ghost</button>
+        <button libButton type="button" variant="danger">Danger</button>
+      `,
+      imports: [ButtonDirective],
+    })
+    class Host {}
+
+    const fixture = await render(Host);
+    const [primary, secondary, ghost, danger] = Array.from(
+      fixture.nativeElement.querySelectorAll('button') as NodeListOf<HTMLButtonElement>
+    );
+
+    expect(primary.classList.contains('hover:bg-primary-hover')).toBe(true);
+    expect(primary.classList.contains('hover:bg-primary-800')).toBe(false);
+
+    expect(secondary.classList.contains('hover:bg-surface-hover')).toBe(true);
+    expect(secondary.classList.contains('hover:bg-surface-100')).toBe(false);
+    expect(secondary.classList.contains('hover:bg-surface-200')).toBe(false);
+
+    expect(ghost.classList.contains('hover:bg-surface-hover')).toBe(true);
+    expect(ghost.classList.contains('hover:bg-surface-100')).toBe(false);
+    expect(ghost.classList.contains('hover:bg-surface-200')).toBe(false);
+
+    expect(danger.classList.contains('bg-red-700')).toBe(true);
+    expect(danger.classList.contains('hover:bg-red-800')).toBe(true);
+    expect(danger.classList.contains('hover:bg-primary-hover')).toBe(false);
+    expect(danger.classList.contains('hover:bg-surface-hover')).toBe(false);
+  });
 });

--- a/libs/shared/src/lib/ui-kit/button/button.directive.ts
+++ b/libs/shared/src/lib/ui-kit/button/button.directive.ts
@@ -18,15 +18,15 @@ export type ButtonSize = 'sm' | 'md' | 'icon';
       'inline-flex cursor-pointer items-center justify-center gap-2 font-medium rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
     '[class.bg-primary]': 'variant() === "primary"',
     '[class.text-primary-foreground]': 'variant() === "primary"',
-    '[class.hover:bg-primary-800]': 'variant() === "primary"',
+    '[class.hover:bg-primary-hover]': 'variant() === "primary"',
     '[class.bg-surface-100]': 'variant() === "secondary"',
     '[class.text-foreground]':
       'variant() === "secondary" || variant() === "ghost"',
     '[class.border]': 'variant() === "secondary"',
     '[class.border-border]': 'variant() === "secondary"',
-    '[class.hover:bg-surface-200]': 'variant() === "secondary"',
+    '[class.hover:bg-surface-hover]':
+      'variant() === "secondary" || variant() === "ghost"',
     '[class.bg-transparent]': 'variant() === "ghost"',
-    '[class.hover:bg-surface-100]': 'variant() === "ghost"',
     '[class.bg-red-700]': 'variant() === "danger"',
     '[class.text-white]': 'variant() === "danger"',
     '[class.hover:bg-red-800]': 'variant() === "danger"',


### PR DESCRIPTION
Primary hover uses primary-hover instead of primary-800; secondary and ghost hover use the ground-tint surface-hover token so dark header ghosts do not flash a light slab. Danger stays a red fill with darker-red hover.

Decisions: no new variants or kit primitives; host-class spec asserts the hover-token contract without snapshotting CSS.

Files: libs/shared ButtonDirective + spec.

Notes: business-portal untouched. Next: remaining UI Theme chrome retoken slices from #77.