### PR TITLE
RALPH: Catalog and Product chrome on semantic tokens (#80, PRD #77)

### DIFF
--- a/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-attribute-facets/catalog-attribute-facets.component.scss
+++ b/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-attribute-facets/catalog-attribute-facets.component.scss
@@ -9,7 +9,7 @@
 .catalog-browse__facet {
   margin-bottom: var(--spacing-100, 1rem);
   padding: 0.75rem 0;
-  border-bottom: 1px solid var(--p-content-border-color, #e5e7eb);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .catalog-browse__facet-label {
@@ -39,13 +39,14 @@
   cursor: pointer;
   font-size: 0.875rem;
   padding: 0.2rem 0.5rem 0.2rem 0.35rem;
-  border-radius: var(--p-border-radius-sm, 4px);
-  border: 1px solid var(--p-content-border-color, #e5e7eb);
-  background: var(--p-content-background, #fff);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
   user-select: none;
   transition: border-color 0.15s, background 0.15s;
 
   &:hover {
-    border-color: var(--p-primary-color, #3b82f6);
+    border-color: var(--color-primary);
+    background: var(--color-surface-hover);
   }
 }

--- a/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-attribute-facets/catalog-attribute-facets.component.spec.ts
+++ b/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-attribute-facets/catalog-attribute-facets.component.spec.ts
@@ -40,5 +40,8 @@ describe('CatalogAttributeFacetsComponent', () => {
     fixture.detectChanges();
 
     expect(emitted).toEqual([{ attributeId: 7, valueId: 3 }]);
+    expect(fixture.nativeElement.textContent).toContain('Color');
+    expect(fixture.nativeElement.textContent).toContain('Red');
+    expect(fixture.nativeElement.innerHTML).not.toMatch(/\bgray-/);
   });
 });

--- a/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-browse-toolbar/catalog-browse-toolbar.component.spec.ts
+++ b/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-browse-toolbar/catalog-browse-toolbar.component.spec.ts
@@ -30,5 +30,13 @@ describe('CatalogBrowseToolbarComponent', () => {
     expect(search.hasAttribute('libInput')).toBe(true);
     expect(sort).toBeTruthy();
     expect(sort.hasAttribute('libSelect')).toBe(true);
+
+    const apply = fixture.nativeElement.querySelector(
+      '.catalog-browse__search-row button',
+    ) as HTMLButtonElement;
+    expect(apply.hasAttribute('libButton')).toBe(true);
+    expect(
+      `${search.className} ${sort.className} ${apply.className}`,
+    ).not.toMatch(/\bgray-/);
   });
 });

--- a/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-browse.page.scss
+++ b/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-browse.page.scss
@@ -16,7 +16,7 @@
 
 .catalog-browse__subtitle {
   margin: 0.25rem 0 0;
-  color: var(--p-text-muted-color, #6b7280);
+  color: color-mix(in srgb, var(--color-foreground) 68%, transparent);
   font-size: 0.95rem;
 }
 
@@ -30,19 +30,19 @@
 }
 
 .catalog-browse__state--error {
-  color: var(--p-red-500, #b91c1c);
+  color: var(--color-red-700);
 }
 
 .catalog-browse__summary {
   margin: 0 0 1rem;
   font-size: 0.9rem;
-  color: var(--p-text-muted-color, #6b7280);
+  color: color-mix(in srgb, var(--color-foreground) 68%, transparent);
 }
 
 .catalog-browse__empty {
   margin: 2rem 0;
   text-align: center;
-  color: var(--p-text-muted-color, #6b7280);
+  color: color-mix(in srgb, var(--color-foreground) 68%, transparent);
 }
 
 .catalog-browse__grid {
@@ -58,10 +58,10 @@
 .catalog-card {
   display: flex;
   flex-direction: column;
-  border-radius: var(--p-border-radius-md, 6px);
-  border: 1px solid var(--p-content-border-color, #e5e7eb);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
   overflow: hidden;
-  background: var(--p-content-background, #fff);
+  background: var(--color-surface);
 }
 
 .catalog-browse__paginator {

--- a/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-browse.page.spec.ts
+++ b/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-browse.page.spec.ts
@@ -111,6 +111,20 @@ describe('CatalogBrowsePageComponent', () => {
     );
   });
 
+  it('retries catalog load with a kit button', () => {
+    errorSig.set('failed');
+
+    const fixture = createFixture();
+    const retry = fixture.nativeElement.querySelector(
+      '.catalog-browse__state--error button',
+    ) as HTMLButtonElement;
+
+    expect(retry).toBeTruthy();
+    expect(retry.hasAttribute('libButton')).toBe(true);
+    retry.click();
+    expect(loadMock).toHaveBeenCalled();
+  });
+
   it('pages the catalog from store page and pageSize, not PrimeNG PaginatorState', () => {
     dataSig.set({
       items: [

--- a/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-category-facet/catalog-category-facet.component.html
+++ b/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-category-facet/catalog-category-facet.component.html
@@ -18,7 +18,6 @@
     <div class="catalog-browse__facet-chips">
       <button
         type="button"
-        libButton
         class="catalog-browse__chip"
         [class.catalog-browse__chip--active]="selectedId() === null"
         (click)="categorySelected.emit(null)"
@@ -28,7 +27,6 @@
       @for (root of roots(); track root.id) {
         <button
           type="button"
-          libButton
           class="catalog-browse__chip"
           [class.catalog-browse__chip--active]="selectedId() === root.id"
           (click)="categorySelected.emit(root.id)"

--- a/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-category-facet/catalog-category-facet.component.scss
+++ b/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-category-facet/catalog-category-facet.component.scss
@@ -1,19 +1,19 @@
 .catalog-browse__facet-hint {
   margin: 0 0 var(--spacing-100, 1rem);
   font-size: 0.9rem;
-  color: var(--p-text-muted-color, #6b7280);
+  color: color-mix(in srgb, var(--color-foreground) 68%, transparent);
 }
 
 .catalog-browse__facet-error {
   margin: 0 0 var(--spacing-100, 1rem);
   font-size: 0.9rem;
-  color: var(--p-red-500, #b91c1c);
+  color: var(--color-red-700);
 }
 
 .catalog-browse__facet {
   margin-bottom: var(--spacing-100, 1rem);
   padding: 0.75rem 0;
-  border-bottom: 1px solid var(--p-content-border-color, #e5e7eb);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .catalog-browse__facet-label {
@@ -32,24 +32,30 @@
 .catalog-browse__chip {
   min-height: 2.25rem;
   padding: 0 0.85rem;
-  border-radius: var(--p-border-radius-md, 999px);
-  border: 1px solid var(--p-content-border-color, #e5e7eb);
-  background: var(--p-content-background, #fff);
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
   color: inherit;
   cursor: pointer;
   font-size: 0.875rem;
 
   &:hover {
-    border-color: var(--p-primary-color, #2563eb);
+    border-color: var(--color-primary);
+    background: var(--color-surface-hover);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-ring);
+    outline-offset: 2px;
   }
 }
 
 .catalog-browse__chip--active {
-  border-color: var(--p-primary-color, #2563eb);
+  border-color: var(--color-primary);
   background: color-mix(
     in srgb,
-    var(--p-primary-color, #2563eb) 12%,
-    transparent
+    var(--color-primary) 12%,
+    var(--color-surface)
   );
   font-weight: 600;
 }
@@ -57,5 +63,5 @@
 .catalog-browse__facet-help {
   margin: 0.5rem 0 0;
   font-size: 0.8rem;
-  color: var(--p-text-muted-color, #6b7280);
+  color: color-mix(in srgb, var(--color-foreground) 68%, transparent);
 }

--- a/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-category-facet/catalog-category-facet.component.spec.ts
+++ b/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-category-facet/catalog-category-facet.component.spec.ts
@@ -1,0 +1,40 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ecommerceTranslocoTestingModule } from '../../../../core/public-api';
+import { CatalogCategoryFacetComponent } from './catalog-category-facet.component';
+
+describe('CatalogCategoryFacetComponent UI Theme', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [CatalogCategoryFacetComponent],
+      providers: [ecommerceTranslocoTestingModule()],
+    });
+  });
+
+  it('keeps category chips as custom markup on semantic tokens, not kit buttons', () => {
+    const fixture = TestBed.createComponent(CatalogCategoryFacetComponent);
+    fixture.componentRef.setInput('roots', [
+      { id: 4, name: 'Ηλεκτρονικά' },
+      { id: 9, name: 'Έπιπλα' },
+    ]);
+    fixture.componentRef.setInput('loading', false);
+    fixture.componentRef.setInput('error', null);
+    fixture.componentRef.setInput('selectedId', 4);
+    fixture.detectChanges();
+
+    const chips = Array.from(
+      fixture.nativeElement.querySelectorAll('.catalog-browse__chip'),
+    ) as HTMLButtonElement[];
+
+    expect(chips.length).toBe(3);
+    expect(chips.map((chip) => chip.textContent?.trim())).toEqual([
+      'Όλα',
+      'Ηλεκτρονικά',
+      'Έπιπλα',
+    ]);
+    for (const chip of chips) {
+      expect(chip.hasAttribute('libButton')).toBe(false);
+      expect(chip.className).not.toMatch(/\bgray-/);
+    }
+  });
+});

--- a/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-category-facet/catalog-category-facet.component.ts
+++ b/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-category-facet/catalog-category-facet.component.ts
@@ -1,13 +1,11 @@
 import { Component, input, output } from '@angular/core';
 import { TranslocoPipe } from '@jsverse/transloco';
 
-import { ButtonDirective } from '@full-stack-nx-workspace/shared';
-
 @Component({
   selector: 'app-catalog-category-facet',
   templateUrl: './catalog-category-facet.component.html',
   styleUrl: './catalog-category-facet.component.scss',
-  imports: [TranslocoPipe, ButtonDirective],
+  imports: [TranslocoPipe],
 })
 export class CatalogCategoryFacetComponent {
   readonly roots = input.required<{ id: number; name: string | null }[]>();

--- a/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-min-rating-facet/catalog-min-rating-facet.component.scss
+++ b/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-min-rating-facet/catalog-min-rating-facet.component.scss
@@ -19,21 +19,36 @@
   min-height: 2rem;
   padding: 0.25rem 0.75rem;
   border-radius: 999px;
-  border: 1px solid var(--p-content-border-color, #e5e7eb);
-  background: var(--p-content-background, #fff);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
   color: inherit;
   cursor: pointer;
   font-size: 0.875rem;
+
+  &:hover {
+    border-color: var(--color-primary);
+    background: var(--color-surface-hover);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-ring);
+    outline-offset: 2px;
+  }
 }
 
 .catalog-browse__chip--active {
-  border-color: var(--p-primary-color, #2563eb);
-  background: var(--p-primary-color, #2563eb);
-  color: var(--p-primary-contrast-color, #fff);
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+  color: var(--color-primary-foreground);
+
+  &:hover {
+    background: var(--color-primary-hover);
+    border-color: var(--color-primary-hover);
+  }
 }
 
 .catalog-browse__facet-help {
   margin: 0.5rem 0 0;
   font-size: 0.8rem;
-  color: var(--p-text-muted-color, #6b7280);
+  color: color-mix(in srgb, var(--color-foreground) 68%, transparent);
 }

--- a/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-min-rating-facet/catalog-min-rating-facet.component.spec.ts
+++ b/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-min-rating-facet/catalog-min-rating-facet.component.spec.ts
@@ -1,0 +1,29 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ecommerceTranslocoTestingModule } from '../../../../core/public-api';
+import { CatalogMinRatingFacetComponent } from './catalog-min-rating-facet.component';
+
+describe('CatalogMinRatingFacetComponent UI Theme', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [CatalogMinRatingFacetComponent],
+      providers: [ecommerceTranslocoTestingModule()],
+    });
+  });
+
+  it('keeps rating chips as custom markup without gray-* or kit buttons', () => {
+    const fixture = TestBed.createComponent(CatalogMinRatingFacetComponent);
+    fixture.componentRef.setInput('selectedMinRating', 4);
+    fixture.detectChanges();
+
+    const chips = Array.from(
+      fixture.nativeElement.querySelectorAll('.catalog-browse__chip'),
+    ) as HTMLButtonElement[];
+
+    expect(chips.length).toBeGreaterThan(1);
+    expect(chips[0].hasAttribute('libButton')).toBe(false);
+    expect(chips.map((chip) => chip.className).join(' ')).not.toMatch(
+      /\bgray-/,
+    );
+  });
+});

--- a/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-price-band/catalog-price-band.component.html
+++ b/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-price-band/catalog-price-band.component.html
@@ -26,14 +26,10 @@
   <div
     class="catalog-browse__price-actions catalog-browse__price-actions--below-slider"
   >
-    <button type="button" class="catalog-browse__btn" (click)="onApply()">
+    <button type="button" libButton (click)="onApply()">
       {{ 'catalog.price.apply' | transloco }}
     </button>
-    <button
-      type="button"
-      class="catalog-browse__btn catalog-browse__btn--secondary"
-      (click)="onClear()"
-    >
+    <button type="button" libButton variant="secondary" (click)="onClear()">
       {{ 'catalog.price.clear' | transloco }}
     </button>
   </div>

--- a/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-price-band/catalog-price-band.component.scss
+++ b/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-price-band/catalog-price-band.component.scss
@@ -1,7 +1,7 @@
 .catalog-browse__price-band {
   margin-bottom: var(--spacing-100, 1rem);
   padding: 0.75rem 0;
-  border-bottom: 1px solid var(--p-content-border-color, #e5e7eb);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .catalog-browse__facet-label {
@@ -30,31 +30,14 @@
   margin-top: 0.25rem;
 }
 
-.catalog-browse__btn {
-  min-height: 2.5rem;
-  padding: 0 1rem;
-  border-radius: var(--p-border-radius-md, 6px);
-  border: none;
-  cursor: pointer;
-  font-weight: 500;
-  background: var(--p-primary-color, #2563eb);
-  color: var(--p-primary-contrast-color, #fff);
-}
-
-.catalog-browse__btn--secondary {
-  background: var(--p-content-background, #fff);
-  color: inherit;
-  border: 1px solid var(--p-content-border-color, #e5e7eb);
-}
-
 .catalog-browse__facet-error {
   margin: 0 0 var(--spacing-100, 1rem);
   font-size: 0.9rem;
-  color: var(--p-red-500, #b91c1c);
+  color: var(--color-red-700);
 }
 
 .catalog-browse__facet-help {
   margin: 0.5rem 0 0;
   font-size: 0.8rem;
-  color: var(--p-text-muted-color, #6b7280);
+  color: color-mix(in srgb, var(--color-foreground) 68%, transparent);
 }

--- a/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-price-band/catalog-price-band.component.spec.ts
+++ b/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-price-band/catalog-price-band.component.spec.ts
@@ -1,0 +1,59 @@
+import { Component, input } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { ecommerceTranslocoTestingModule } from '../../../../core/public-api';
+import {
+  PriceRangeDisplayComponent,
+  PriceRangeDisplayTemplateDirective,
+  PriceRangeSliderComponent,
+} from '../../../../ui/public-api';
+import { CatalogPriceBandComponent } from './catalog-price-band.component';
+
+@Component({
+  selector: 'app-price-range-slider',
+  template: '',
+})
+class StubPriceRangeSliderComponent {
+  readonly min = input(0);
+  readonly max = input(0);
+  readonly options = input<unknown>(null);
+}
+
+describe('CatalogPriceBandComponent UI Theme', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [CatalogPriceBandComponent],
+      providers: [ecommerceTranslocoTestingModule()],
+    }).overrideComponent(CatalogPriceBandComponent, {
+      remove: {
+        imports: [
+          PriceRangeSliderComponent,
+          PriceRangeDisplayComponent,
+          PriceRangeDisplayTemplateDirective,
+        ],
+      },
+      add: { imports: [StubPriceRangeSliderComponent] },
+    });
+  });
+
+  it('uses kit buttons for price apply and clear', () => {
+    const fixture = TestBed.createComponent(CatalogPriceBandComponent);
+    fixture.componentRef.setInput('salePriceMin', null);
+    fixture.componentRef.setInput('salePriceMax', null);
+    fixture.detectChanges();
+
+    const buttons = Array.from(
+      fixture.nativeElement.querySelectorAll(
+        '.catalog-browse__price-actions button',
+      ),
+    ) as HTMLButtonElement[];
+
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0].hasAttribute('libButton')).toBe(true);
+    expect(buttons[1].hasAttribute('libButton')).toBe(true);
+    expect(buttons[1].getAttribute('variant')).toBe('secondary');
+    expect(buttons.map((button) => button.className).join(' ')).not.toMatch(
+      /\bgray-/,
+    );
+  });
+});

--- a/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-price-band/catalog-price-band.component.ts
+++ b/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-price-band/catalog-price-band.component.ts
@@ -9,6 +9,8 @@ import {
 import { ChangeContext, Options } from '@angular-slider/ngx-slider';
 import { TranslocoPipe } from '@jsverse/transloco';
 
+import { ButtonDirective } from '@full-stack-nx-workspace/shared';
+
 import {
   PriceRangeDisplayComponent,
   PriceRangeDisplayTemplateDirective,
@@ -29,6 +31,7 @@ export interface PriceRange {
   styleUrl: './catalog-price-band.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
+    ButtonDirective,
     PriceRangeDisplayComponent,
     PriceRangeDisplayTemplateDirective,
     PriceRangeSliderComponent,

--- a/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-product-card/catalog-product-card.component.scss
+++ b/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-product-card/catalog-product-card.component.scss
@@ -1,6 +1,6 @@
 .catalog-card__media {
   aspect-ratio: 4 / 3;
-  background: var(--p-surface-100, #f3f4f6);
+  background: var(--color-surface-hover);
 }
 
 .catalog-card__link {
@@ -43,7 +43,7 @@
 .catalog-card__rating {
   margin: 0;
   font-size: 0.875rem;
-  color: var(--p-text-muted-color, #6b7280);
+  color: color-mix(in srgb, var(--color-foreground) 68%, transparent);
   display: flex;
   align-items: baseline;
   gap: 0.25rem;
@@ -63,7 +63,7 @@
 .catalog-card__options {
   margin: 0;
   font-size: 0.8rem;
-  color: var(--p-text-muted-color, #6b7280);
+  color: color-mix(in srgb, var(--color-foreground) 68%, transparent);
 }
 
 .catalog-card__cart {
@@ -79,18 +79,24 @@
   justify-content: center;
   width: 2rem;
   height: 2rem;
-  border: 1px solid var(--p-primary-color, #6366f1);
+  border: 1px solid var(--color-primary);
   border-radius: 50%;
   background: transparent;
-  color: var(--p-primary-color, #6366f1);
+  color: var(--color-primary);
   font-size: 1.25rem;
   line-height: 1;
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
 
   &:hover:not([disabled]) {
-    background: var(--p-primary-color, #6366f1);
-    color: #fff;
+    background: var(--color-primary-hover);
+    border-color: var(--color-primary-hover);
+    color: var(--color-primary-foreground);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-ring);
+    outline-offset: 2px;
   }
 
   &[disabled] {

--- a/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-product-card/catalog-product-card.component.spec.ts
+++ b/apps/ecommerce/src/app/domains/catalog/feat-browse/catalog-product-card/catalog-product-card.component.spec.ts
@@ -80,6 +80,24 @@ describe('CatalogProductCardComponent', () => {
     expect(spinner.getAttribute('aria-label')).toBe('Ενημέρωση ποσότητας');
   });
 
+  it('renders stored Product name and image URL without gray-* chrome classes', () => {
+    const fixture = createFixture({
+      ...baseItem,
+      name: 'Stored Shirt',
+      primaryImageUrl: 'https://cdn.example/shirt.jpg',
+    });
+
+    const img = fixture.nativeElement.querySelector(
+      'img',
+    ) as HTMLImageElement;
+
+    expect(fixture.nativeElement.textContent).toContain('Stored Shirt');
+    expect(img.src).toContain('https://cdn.example/shirt.jpg');
+    expect(img.getAttribute('alt')).toBe('Stored Shirt');
+    expect(fixture.nativeElement.innerHTML).not.toMatch(/\bgray-/);
+    expect(fixture.nativeElement.innerHTML).not.toMatch(/--p-/);
+  });
+
   it('hides the star score when the product has no reviews', () => {
     const fixture = createFixture(baseItem);
 

--- a/apps/ecommerce/src/app/domains/product/feat-detail/product-detail.page.html
+++ b/apps/ecommerce/src/app/domains/product/feat-detail/product-detail.page.html
@@ -135,7 +135,8 @@
       <div class="product-detail__my-review-actions">
         <button
           type="button"
-          class="product-detail__btn"
+          libButton
+          variant="secondary"
           [disabled]="submission.saving()"
           (click)="startEdit()"
         >
@@ -143,7 +144,8 @@
         </button>
         <button
           type="button"
-          class="product-detail__btn product-detail__btn--danger"
+          libButton
+          variant="danger"
           [disabled]="submission.saving()"
           (click)="deleteReview()"
         >
@@ -192,26 +194,28 @@
 
       <label class="product-detail__form-field">
         <span>{{ 'product.titleLabel' | transloco }}</span>
-        <input type="text" formControlName="title" maxlength="120" />
+        <input libInput type="text" formControlName="title" maxlength="120" />
       </label>
 
       <label class="product-detail__form-field">
         <span>{{ 'product.bodyLabel' | transloco }}</span>
-        <textarea formControlName="body" rows="4" maxlength="2000"></textarea>
+        <textarea
+          class="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+          formControlName="body"
+          rows="4"
+          maxlength="2000"
+        ></textarea>
       </label>
 
       <div class="product-detail__form-actions">
-        <button
-          type="submit"
-          class="product-detail__btn product-detail__btn--primary"
-          [disabled]="submission.saving()"
-        >
+        <button type="submit" libButton [disabled]="submission.saving()">
           {{ (editing() ? 'product.save' : 'product.submit') | transloco }}
         </button>
         @if (editing()) {
         <button
           type="button"
-          class="product-detail__btn"
+          libButton
+          variant="secondary"
           [disabled]="submission.saving()"
           (click)="cancelEdit()"
         >

--- a/apps/ecommerce/src/app/domains/product/feat-detail/product-detail.page.scss
+++ b/apps/ecommerce/src/app/domains/product/feat-detail/product-detail.page.scss
@@ -31,6 +31,7 @@
 .product-detail__state--error {
   flex-direction: column;
   align-items: flex-start;
+  color: var(--color-red-700);
 }
 
 .product-detail__aggregate {
@@ -45,12 +46,12 @@
 }
 
 .product-detail__aggregate-count {
-  color: #4b5563;
+  color: color-mix(in srgb, var(--color-foreground) 68%, transparent);
 }
 
 .product-detail__empty {
   margin: 0;
-  color: #4b5563;
+  color: color-mix(in srgb, var(--color-foreground) 68%, transparent);
 }
 
 .product-detail__review-list {
@@ -66,8 +67,9 @@
   display: grid;
   gap: 0.35rem;
   padding: 1rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
 }
 
 .product-detail__review-stars {
@@ -76,11 +78,11 @@
 }
 
 .product-detail__star {
-  color: #d1d5db;
+  color: color-mix(in srgb, var(--color-foreground) 28%, transparent);
 }
 
 .product-detail__star--filled {
-  color: #f59e0b;
+  color: var(--color-amber-500);
 }
 
 .product-detail__review-author {
@@ -89,7 +91,7 @@
 }
 
 .product-detail__review-date {
-  color: #6b7280;
+  color: color-mix(in srgb, var(--color-foreground) 68%, transparent);
   font-size: 0.875rem;
 }
 
@@ -108,12 +110,12 @@
   flex-direction: column;
   gap: 1rem;
   padding-top: 1.5rem;
-  border-top: 1px solid #e5e7eb;
+  border-top: 1px solid var(--color-border);
 }
 
 .product-detail__gate {
   margin: 0;
-  color: #4b5563;
+  color: color-mix(in srgb, var(--color-foreground) 68%, transparent);
 }
 
 .product-detail__gate a {
@@ -125,8 +127,9 @@
   display: grid;
   gap: 0.5rem;
   padding: 1rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
 }
 
 .product-detail__my-review-actions,
@@ -162,12 +165,17 @@
   cursor: pointer;
   font-size: 1.75rem;
   line-height: 1;
-  color: #d1d5db;
+  color: color-mix(in srgb, var(--color-foreground) 28%, transparent);
   padding: 0;
+
+  &:focus-visible {
+    outline: 2px solid var(--color-ring);
+    outline-offset: 2px;
+  }
 }
 
 .product-detail__rating-star--filled {
-  color: #f59e0b;
+  color: var(--color-amber-500);
 }
 
 .product-detail__form-field {
@@ -176,41 +184,9 @@
   gap: 0.25rem;
 }
 
-.product-detail__form-field input,
-.product-detail__form-field textarea {
-  padding: 0.5rem;
-  border: 1px solid #d1d5db;
-  border-radius: 0.375rem;
-  font: inherit;
-}
-
 .product-detail__field-error,
 .product-detail__write-error {
   margin: 0;
-  color: #b91c1c;
+  color: var(--color-red-700);
   font-size: 0.875rem;
-}
-
-.product-detail__btn {
-  cursor: pointer;
-  padding: 0.5rem 1rem;
-  border: 1px solid #d1d5db;
-  border-radius: 0.375rem;
-  background: #fff;
-}
-
-.product-detail__btn--primary {
-  background: #2563eb;
-  border-color: #2563eb;
-  color: #fff;
-}
-
-.product-detail__btn--danger {
-  border-color: #b91c1c;
-  color: #b91c1c;
-}
-
-.product-detail__btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
 }

--- a/apps/ecommerce/src/app/domains/product/feat-detail/product-detail.page.spec.ts
+++ b/apps/ecommerce/src/app/domains/product/feat-detail/product-detail.page.spec.ts
@@ -317,6 +317,33 @@ describe('ProductDetailPageComponent', () => {
       expect(
         fixture.debugElement.query(By.css('.product-detail__form')),
       ).toBeNull();
+
+      const buttons = Array.from(
+        actions.nativeElement.querySelectorAll('button'),
+      ) as HTMLButtonElement[];
+      expect(buttons).toHaveLength(2);
+      expect(buttons[0].hasAttribute('libButton')).toBe(true);
+      expect(buttons[1].hasAttribute('libButton')).toBe(true);
+      expect(buttons[1].getAttribute('variant')).toBe('danger');
+      expect(fixture.nativeElement.textContent).toContain('Καλό');
+      expect(fixture.nativeElement.innerHTML).not.toMatch(/\bgray-/);
+      expect(fixture.nativeElement.innerHTML).not.toMatch(/--p-/);
+    });
+
+    it('uses kit fields and a primary CTA on the review form', () => {
+      isAuthenticatedSig.set(true);
+
+      const fixture = createFixture();
+      const title = fixture.nativeElement.querySelector(
+        'input[formControlName="title"]',
+      ) as HTMLInputElement;
+      const submit = fixture.nativeElement.querySelector(
+        '.product-detail__form-actions button[type="submit"]',
+      ) as HTMLButtonElement;
+
+      expect(title.hasAttribute('libInput')).toBe(true);
+      expect(submit.hasAttribute('libButton')).toBe(true);
+      expect(fixture.nativeElement.innerHTML).not.toMatch(/\bgray-/);
     });
   });
 });

--- a/apps/ecommerce/src/app/domains/product/feat-detail/product-detail.page.ts
+++ b/apps/ecommerce/src/app/domains/product/feat-detail/product-detail.page.ts
@@ -13,6 +13,7 @@ import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
 
 import {
   ButtonDirective,
+  InputDirective,
   PaginatorComponent,
   SpinnerComponent,
   type PaginatorPageChange,
@@ -34,6 +35,7 @@ import {
     ReactiveFormsModule,
     NgTemplateOutlet,
     ButtonDirective,
+    InputDirective,
     PaginatorComponent,
     SpinnerComponent,
     TranslocoPipe,

--- a/apps/ecommerce/src/app/ui/price-range-slider/price-range-slider.component.scss
+++ b/apps/ecommerce/src/app/ui/price-range-slider/price-range-slider.component.scss
@@ -1,12 +1,16 @@
 ::ng-deep {
   .slider-container {
     .ngx-slider .ngx-slider-bar {
-      background: var(--p-primary-100);
+      background: color-mix(
+        in srgb,
+        var(--color-primary) 18%,
+        var(--color-surface)
+      );
       height: 4px;
     }
 
     .ngx-slider .ngx-slider-selection {
-      background: var(--p-primary-color);
+      background: var(--color-primary);
     }
 
     &.square-pointer {
@@ -15,7 +19,7 @@
         height: 12px;
         border-radius: 0;
         top: -4px;
-        background-color: var(--p-primary-color);
+        background-color: var(--color-primary);
       }
 
       :focus {
@@ -35,7 +39,7 @@
       font-weight: bold;
 
       &.ngx-slider-ceil {
-        color: var(--p-primary-color);
+        color: var(--color-primary);
       }
     }
 
@@ -44,7 +48,11 @@
       height: 10px;
       margin-left: 4px;
       border-radius: 0;
-      background: var(--p-primary-100);
+      background: color-mix(
+        in srgb,
+        var(--color-primary) 18%,
+        var(--color-surface)
+      );
       top: -1px;
     }
   }


### PR DESCRIPTION
Catalog browse and Product detail follow UI Theme in both appearances: chips, fields, cards, price band, and review chrome drop --p-* / light hex fallbacks. Category names, Product names, and images stay as stored.

Decisions: category and rating chips stay custom markup (no Chip primitive, no libButton on chips) so they do not fight kit CTAs; price apply/clear and review actions move onto libButton; muted text mixes foreground instead of a light-absolute gray.

Files: ecommerce catalog feat-browse chrome + specs, product-detail page + spec, price-range-slider tokens.

Notes: business-portal untouched. Manual check still needed: Catalog browse and Product detail in light and dark, including primary and ghost hover. Next: remaining UI Theme chrome retoken slices from #77 (cart/checkout/assistant).